### PR TITLE
Get Agent binaries from its final path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: mcr.microsoft.com/dotnet/core/sdk:3.1
 
 variables:
-  AGENT_DOWNLOAD_URL: "http://s3.amazonaws.com/ddagent-windows-unstable/cf-windows-7.17.0-rc.4.git.35.7bd7ba0-1-x86_64.zip"
+  AGENT_DOWNLOAD_URL: "http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.18.0-rc.1-1-x86_64.zip"
   TRACER_DOWNLOAD_URL: "https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.13.0/windows-tracer-home.zip"
   TRACER_CONTENT_DIR: $CI_PROJECT_DIR/content/Tracer
   AGENT_CONTENT_DIR: $CI_PROJECT_DIR/content/Agent

--- a/set-versions.bat
+++ b/set-versions.bat
@@ -4,12 +4,15 @@ set major=0
 set minor=2
 set patch=1
 set version_postfix=-prerelease
+set agent_version=7.18.0-rc.1
 set tracer_version=1.13.0
 REM All of the below code changes the actual files, no touch!
 
-set version_regex=[0-9]+\.[0-9]+\.[0-9]+[\-a-zA-Z]*
 set gitlab_yml=.gitlab-ci.yml
+set version_regex=[0-9]+\.[0-9]+\.[0-9]+[\-a-zA-Z]*
 powershell -Command "(gc .\%gitlab_yml%) -replace '%version_regex%.+windows-tracer-home.zip', '%tracer_version%/windows-tracer-home.zip' | Out-File -encoding ASCII .\%gitlab_yml%"
+set version_regex=[0-9]+\.[0-9]+\.[0-9]+[\-\.a-zA-Z0-9]*
+powershell -Command "(gc .\%gitlab_yml%) -replace 'agent-binaries-%version_regex%-1-x86_64.zip', 'agent-binaries-%agent_version%-1-x86_64.zip' | Out-File -encoding ASCII .\%gitlab_yml%"
 
 set nuget_replacement=%major%.%minor%.%patch%%version_postfix%
 


### PR DESCRIPTION
From v7.18.0-rc.1 onwards, the Agent build pipeline outputs a zip with the puppy, dogstatsd, trace and process agents to S3, so we can pull it here.