### PR TITLE
Add ASP.NET integration by adding HttpModule to configuration

### DIFF
--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -65,4 +65,11 @@
       </environmentVariables>
     </runtime>
   </system.webServer>
+  <location path="%XDT_SITENAME%" xdt:Locator="Match(path)">
+    <system.webServer xdt:Transform="InsertIfMissing">
+      <modules xdt:Transform="InsertIfMissing">
+        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+      </modules>
+    </system.webServer>
+  </location>
 </configuration>

--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -68,7 +68,7 @@
   <location path="%XDT_SITENAME%" xdt:Locator="Match(path)">
     <system.webServer xdt:Transform="InsertIfMissing">
       <modules xdt:Transform="InsertIfMissing">
-        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet" preCondition="managedHandler,runtimeVersionv4.0" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </modules>
     </system.webServer>
   </location>


### PR DESCRIPTION
Add the `Datadog.Trace.AspNet.TracingHttpModule` via a `system.webServer/modules` entry in the `applicationHost.xdt` file. This works because by the time the application is attempting to load the `HttpModule`, we have already added the `AppDomain.AssemblyResolve` event to look into the profiler directory for missing assemblies (e.g. `Datadog.Trace.AspNet.dll`).

I followed the Kudu documentation to add this: https://github.com/projectkudu/kudu/wiki/Xdt-transform-samples#registering-an-iis-managed-httpmodule

Note: The following test result was achieved after updating the App Service to use the latest `Datadog.AzureAppServices` v0.2.8-prerelease then rewriting the `D:\home\SiteExtensions\Datadog.AzureAppServices\applicationHost.xdt` file

<img width="669" alt="aas-aspnet" src="https://user-images.githubusercontent.com/13769665/80118863-d28a4e00-853d-11ea-96ca-81841492fbaf.PNG">
