### PR TITLE
Add missing CORECLR_PROFILER_PATH_64 to applicationHost.xdt

### DIFF
--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -38,6 +38,7 @@
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\datadog\tracer\v0_3_2\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\datadog\tracer\v0_3_2\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 		
         <add name="DD_DOTNET_TRACER_HOME" value="%HOME%\datadog\tracer\v0_3_2" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_INTEGRATIONS" value="%HOME%\datadog\tracer\v0_3_2\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>


### PR DESCRIPTION
The CORECLR_PROFILER_PATH_64 environment variable was missing from applicationHost.xdt. This appears to have been just an oversight, which meant that profiling wasn't enabled for 64bit .NET Core processes.

I have tested this change manually on an Azure App Service running [eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb) deployed as `win-x64`, and verified that spans properly appear in Live Tail.