### PR TITLE
Update Site Extension to 0.3.11-prerelease with Agent 7.22.1 and .NET Tracer 1.19.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ image: mcr.microsoft.com/dotnet/core/sdk:3.1
 
 variables:
   AGENT_DOWNLOAD_URL: "http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.22.1-1-x86_64.zip"
-  TRACER_DOWNLOAD_URL: "https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.19.3/windows-tracer-home.zip"
+  TRACER_DOWNLOAD_URL: "https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.19.4/windows-tracer-home.zip"
   TRACER_CONTENT_DIR: $CI_PROJECT_DIR/content/Tracer
   AGENT_CONTENT_DIR: $CI_PROJECT_DIR/content/Agent
 

--- a/Datadog.AzureAppServices.nuspec
+++ b/Datadog.AzureAppServices.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Datadog.AzureAppServices</id>
-    <version>0.3.10-prerelease</version>
+    <version>0.3.11-prerelease</version>
     <title>.NET Datadog APM [Beta]</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/Datadog.Development.AzureAppServices.nuspec
+++ b/Datadog.Development.AzureAppServices.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Datadog.Development.AzureAppServices</id>
-    <version>0.3.10-prerelease</version>
+    <version>0.3.11-prerelease</version>
     <title>Very Experimental .NET Datadog APM</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/content/Agent/datadog.yaml
+++ b/content/Agent/datadog.yaml
@@ -2,5 +2,5 @@
 hostname: none
 apm_config:
   enabled: true
-  log_file: D:\home\LogFiles\datadog\v0_3_10\trace-log.txt
+  log_file: D:\home\LogFiles\datadog\v0_3_11\trace-log.txt
 ## log_level: debug

--- a/content/Agent/dogstatsd.yaml
+++ b/content/Agent/dogstatsd.yaml
@@ -1,5 +1,5 @@
 ## hostname: none is required for special billing considerations
 hostname: none
 use_dogstatsd: true
-log_file: D:\home\LogFiles\datadog\v0_3_10\dogstatsd.txt
+log_file: D:\home\LogFiles\datadog\v0_3_11\dogstatsd.txt
 ## log_level: debug

--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -34,24 +34,24 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\datadog\tracer\v0_3_10\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\datadog\tracer\v0_3_10\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\datadog\tracer\v0_3_10\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\datadog\tracer\v0_3_11\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\datadog\tracer\v0_3_11\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\datadog\tracer\v0_3_11\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\datadog\tracer\v0_3_10\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\datadog\tracer\v0_3_10\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\datadog\tracer\v0_3_11\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\datadog\tracer\v0_3_11\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="DD_DOTNET_TRACER_HOME" value="%HOME%\datadog\tracer\v0_3_10" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_INTEGRATIONS" value="%HOME%\datadog\tracer\v0_3_10\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\v0_3_10\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOTNET_TRACER_HOME" value="%HOME%\datadog\tracer\v0_3_11" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_INTEGRATIONS" value="%HOME%\datadog\tracer\v0_3_11\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\v0_3_11\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_AGENT_PATH" value="%HOME%\datadog\tracer\v0_3_10\agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_AGENT_ARGS" value="--config %HOME%\datadog\tracer\v0_3_10\agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_DOGSTATSD_PATH" value="%HOME%\datadog\tracer\v0_3_10\agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_DOGSTATSD_ARGS" value="start -c %HOME%\datadog\tracer\v0_3_10\agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_AGENT_PATH" value="%HOME%\datadog\tracer\v0_3_11\agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_AGENT_ARGS" value="--config %HOME%\datadog\tracer\v0_3_11\agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOGSTATSD_PATH" value="%HOME%\datadog\tracer\v0_3_11\agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOGSTATSD_ARGS" value="start -c %HOME%\datadog\tracer\v0_3_11\agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_TRACE_METRICS_ENABLED" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>

--- a/content/install.cmd
+++ b/content/install.cmd
@@ -8,7 +8,7 @@ echo Extension directory is %extensionBaseDir%
 echo Site root directory is %siteHome%
 
 REM Create home directory for tracer version
-SET tracerDir=%siteHome%\datadog\tracer\v0_3_10
+SET tracerDir=%siteHome%\datadog\tracer\v0_3_11
 if not exist %tracerDir% mkdir %tracerDir%
 
 REM Copy tracer home directory to version specific directory

--- a/set-versions.bat
+++ b/set-versions.bat
@@ -4,14 +4,14 @@ REM Set these version variables and run the script to change all the files which
 REM The site extension version
 set major=0
 set minor=3
-set patch=10
+set patch=11
 set version_postfix=-prerelease
 
 REM The agent version
 set agent_version=7.22.1
 
 REM The dotnet tracer version
-set tracer_version=1.19.3
+set tracer_version=1.19.4
 
 REM *************************************************************
 REM All of the below code updates versions in files, do not touch


### PR DESCRIPTION
.NET Tracer 1.19.4: [Download](https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.19.4/windows-tracer-home.zip)
Datadog Agent 7.22.1: [Download](http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.22.1-1-x86_64.zip)