### PR TITLE
Set pipe name variables on install

### DIFF
--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -66,7 +66,3 @@
     </runtime>
   </system.webServer>
 </configuration>
-
-
-
-

--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -30,6 +30,9 @@
         <add name="DD_TRACE_METRICS_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_PROFILER_EXCLUDE_PROCESSES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+
         <!-- We're unable to instrument domain-neutral assemblies when our managed assemblies are not in the GAC, so force LoaderOptimization to be LoaderOptimization.SingleDomain -->
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -55,7 +58,15 @@
 
         <add name="DD_TRACE_METRICS_ENABLED" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+		
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+		
       </environmentVariables>
     </runtime>
   </system.webServer>
 </configuration>
+
+
+
+

--- a/content/install.cmd
+++ b/content/install.cmd
@@ -21,4 +21,6 @@ if not exist %agentDir% mkdir %agentDir%
 REM Copy all agent files
 ROBOCOPY %extensionBaseDir%Agent %agentDir% /E /purge
 
+POWERSHELL .\install.ps1
+
 echo Finished install

--- a/content/install.ps1
+++ b/content/install.ps1
@@ -1,0 +1,6 @@
+
+$tracePipeId=([guid]::NewGuid().ToString().ToUpper())
+$statsPipeId=([guid]::NewGuid().ToString().ToUpper())
+
+((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueTracePipeId", "${tracePipeId}") | Set-Content -Path .\applicationHost.xdt
+((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueStatsPipeId", "${statsPipeId}") | Set-Content -Path .\applicationHost.xdt


### PR DESCRIPTION
Call a powershell script to modify the `applicationHost.xdt` file at install time.
Use a guid to ensure unique pipe name per install.