### PR TITLE
Only add the HttpModule for .NET Framework applications

### DIFF
--- a/content/applicationHost.xdt
+++ b/content/applicationHost.xdt
@@ -83,7 +83,7 @@
   <location path="%XDT_SITENAME%" xdt:Locator="Match(path)">
     <system.webServer xdt:Transform="InsertIfMissing">
       <modules xdt:Transform="InsertIfMissing">
-        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule,Datadog.Trace.AspNet,Version=1.0.0.0,Culture=neutral,PublicKeyToken=def86d061d0d2eeb" preCondition="managedHandler,runtimeVersionv4.0" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </modules>
     </system.webServer>
   </location>


### PR DESCRIPTION
Modify the addition of the Datadog.Trace.AspNet.TracingHttpModule to match the definition used by the MSI for Windows installations