### PR TITLE
Disable internal metrics by default

### DIFF
--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -63,7 +63,7 @@
         <add name="DD_DOGSTATSD_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices\v0_3_15\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_DOGSTATSD_ARGS" value="start -c %HOME%\SiteExtensions\Datadog.AzureAppServices\v0_3_15\Agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="DD_TRACE_METRICS_ENABLED" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_METRICS_ENABLED" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 		
         <add name="DD_TRACE_TRANSPORT" value="DATADOG-NAMED-PIPES" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	


### PR DESCRIPTION
Disable internal metrics until RyuJIT ThreadAbortException fix vendored
https://github.com/DataDog/dogstatsd-csharp-client/commit/0877097e1e29198b629a210648ea5ee5bbc47823

This will be done in the tracer, vendoring the v6 client.