### PR TITLE
Launch AspNet integration from profiler instead of IIS config

### DIFF
--- a/dotnet/content/applicationHost.xdt.dd
+++ b/dotnet/content/applicationHost.xdt.dd
@@ -86,11 +86,4 @@
       </environmentVariables>
     </runtime>
   </system.webServer>
-  <location path="%XDT_SITENAME%" xdt:Locator="Match(path)">
-    <system.webServer xdt:Transform="InsertIfMissing">
-      <modules xdt:Transform="InsertIfMissing">
-        <add name="DatadogTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule,Datadog.Trace.AspNet,Version=1.0.0.0,Culture=neutral,PublicKeyToken=def86d061d0d2eeb" preCondition="managedHandler,runtimeVersionv4.0" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-      </modules>
-    </system.webServer>
-  </location>
 </configuration>


### PR DESCRIPTION
- Remove Datadog.Trace.AspNet.TracingHttpModule from applicationHost.xdt
- TODO: Update .NET Tracer version with latest version that contains the change