### PR TITLE
Increment Dev Version for Agent v7.30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj/
 /dotnet/content/Tracer/*
 /dotnet/content/Agent/dogstatsd.exe
 /dotnet/content/Agent/datadog-trace-agent.exe
+/package/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   RELEASE_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0
   RELEASE_TRACER_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0/Tracer
   RELEASE_AGENT_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0/Agent
-  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_30
+  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_31
 
 dotnet-package:
   tags: [ "runner:main", "size:2xlarge" ]
@@ -34,12 +34,12 @@ dotnet-package:
     - echo "Creating nuget package"
     - echo "Packing nuspec file via arcane roundabout csproj process"
     - dotnet pack dotnet/Datadog.AzureAppServices.DotNet.csproj -p:NoBuild=true -p:NoDefaultExcludes=true -o package
-    - echo "Updating versions from v1_5_0 to v0_1_30 for testing package"
-    - sed -i 's/v1_5_0/v0_1_30/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/EXTENSION_VERSION" value="1.5.0"/EXTENSION_VERSION" value="0.1.30"/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/v1_5_0/v0_1_30/g' $RELEASE_AGENT_DIR/datadog.yaml
-    - sed -i 's/v1_5_0/v0_1_30/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
-    - sed -i 's/v1.5.0/v0.1.30/g' $BASE_DIR/install.cmd
+    - echo "Updating versions from v1_5_0 to v0_1_31 for testing package"
+    - sed -i 's/v1_5_0/v0_1_31/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/EXTENSION_VERSION" value="1.5.0"/EXTENSION_VERSION" value="0.1.31"/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/v1_5_0/v0_1_31/g' $RELEASE_AGENT_DIR/datadog.yaml
+    - sed -i 's/v1_5_0/v0_1_31/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
+    - sed -i 's/v1.5.0/v0.1.31/g' $BASE_DIR/install.cmd
     - echo "Updating paths from Datadog.AzureAppServices.DotNet to DevelopmentVerification.DdDotNet.Apm for testing package"
     - sed -i 's/Datadog.AzureAppServices.DotNet/DevelopmentVerification.DdDotNet.Apm/g' $BASE_DIR/applicationHost.xdt
     - mkdir $DEVELOPMENT_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   RELEASE_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0
   RELEASE_TRACER_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0/Tracer
   RELEASE_AGENT_DIR: $CI_PROJECT_DIR/dotnet/content/v1_5_0/Agent
-  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_31
+  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_32
 
 dotnet-package:
   tags: [ "runner:main", "size:2xlarge" ]
@@ -34,12 +34,12 @@ dotnet-package:
     - echo "Creating nuget package"
     - echo "Packing nuspec file via arcane roundabout csproj process"
     - dotnet pack dotnet/Datadog.AzureAppServices.DotNet.csproj -p:NoBuild=true -p:NoDefaultExcludes=true -o package
-    - echo "Updating versions from v1_5_0 to v0_1_31 for testing package"
-    - sed -i 's/v1_5_0/v0_1_31/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/EXTENSION_VERSION" value="1.5.0"/EXTENSION_VERSION" value="0.1.31"/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/v1_5_0/v0_1_31/g' $RELEASE_AGENT_DIR/datadog.yaml
-    - sed -i 's/v1_5_0/v0_1_31/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
-    - sed -i 's/v1.5.0/v0.1.31/g' $BASE_DIR/install.cmd
+    - echo "Updating versions from v1_5_0 to v0_1_32 for testing package"
+    - sed -i 's/v1_5_0/v0_1_32/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/EXTENSION_VERSION" value="1.5.0"/EXTENSION_VERSION" value="0.1.32"/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/v1_5_0/v0_1_32/g' $RELEASE_AGENT_DIR/datadog.yaml
+    - sed -i 's/v1_5_0/v0_1_32/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
+    - sed -i 's/v1.5.0/v0.1.32/g' $BASE_DIR/install.cmd
     - echo "Updating paths from Datadog.AzureAppServices.DotNet to DevelopmentVerification.DdDotNet.Apm for testing package"
     - sed -i 's/Datadog.AzureAppServices.DotNet/DevelopmentVerification.DdDotNet.Apm/g' $BASE_DIR/applicationHost.xdt
     - mkdir $DEVELOPMENT_DIR

--- a/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
+++ b/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>DevelopmentVerification.DdDotNet.Apm</id>
-    <version>0.1.30-prerelease</version>
+    <version>0.1.31-prerelease</version>
     <title>Experimental Extension</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
+++ b/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>DevelopmentVerification.DdDotNet.Apm</id>
-    <version>0.1.31-prerelease</version>
+    <version>0.1.32-prerelease</version>
     <title>Experimental Extension</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/set-dotnet-versions.bat
+++ b/set-dotnet-versions.bat
@@ -8,9 +8,9 @@ set version_postfix=
 
 REM Specialized version for development package, increment as necessary for testing
 set development_minor=1
-set development_patch=30
+set development_patch=31
 
-REM The agent version to deploy
+REM The agent version to deploy (Manually including 7.30 pre-upload)
 set agent_version=7.25.0
 
 REM The dotnet tracer version to deploy

--- a/set-dotnet-versions.bat
+++ b/set-dotnet-versions.bat
@@ -8,7 +8,7 @@ set version_postfix=
 
 REM Specialized version for development package, increment as necessary for testing
 set development_minor=1
-set development_patch=31
+set development_patch=32
 
 REM The agent version to deploy (Manually including 7.30 pre-upload)
 set agent_version=7.25.0


### PR DESCRIPTION
For releasing a development version to deploy to all the samples in order to verify v.730 of the agent before release.
Manual build on my local machine, this is to keep the version in sync.
![image](https://user-images.githubusercontent.com/1801443/128528137-d5146444-50ff-432f-8f36-7b73c12e5aa0.png)
