### PR TITLE
Update the .NET Tracer version to 1.29.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,13 +2,13 @@ image: mcr.microsoft.com/dotnet/core/sdk:3.1
 
 variables:
   DOTNET_AGENT_DOWNLOAD_URL: "http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.31.1-1-x86_64.zip" 
-  DOTNET_TRACER_DOWNLOAD_URL: "https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.28.8/windows-tracer-home.zip"
+  DOTNET_TRACER_DOWNLOAD_URL: "https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.29.0/windows-tracer-home.zip"
   AGENT_CONFIG_DIR: $CI_PROJECT_DIR/dotnet/content/Agent
   BASE_DIR: $CI_PROJECT_DIR/dotnet/content/
-  RELEASE_DIR: $CI_PROJECT_DIR/dotnet/content/v1_7_0
-  RELEASE_TRACER_DIR: $CI_PROJECT_DIR/dotnet/content/v1_7_0/Tracer
-  RELEASE_AGENT_DIR: $CI_PROJECT_DIR/dotnet/content/v1_7_0/Agent
-  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_41
+  RELEASE_DIR: $CI_PROJECT_DIR/dotnet/content/v1_8_0
+  RELEASE_TRACER_DIR: $CI_PROJECT_DIR/dotnet/content/v1_8_0/Tracer
+  RELEASE_AGENT_DIR: $CI_PROJECT_DIR/dotnet/content/v1_8_0/Agent
+  DEVELOPMENT_DIR: $CI_PROJECT_DIR/dotnet/content/v0_1_42
 
 dotnet-package:
   tags: [ "runner:main", "size:2xlarge" ]
@@ -34,12 +34,12 @@ dotnet-package:
     - echo "Creating nuget package"
     - echo "Packing nuspec file via arcane roundabout csproj process"
     - dotnet pack dotnet/Datadog.AzureAppServices.DotNet.csproj -p:NoBuild=true -p:NoDefaultExcludes=true -o package
-    - echo "Updating versions from v1_7_0 to v0_1_41 for testing package"
-    - sed -i 's/v1_7_0/v0_1_41/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/EXTENSION_VERSION" value="1.7.0"/EXTENSION_VERSION" value="0.1.41"/g' dotnet/content/applicationHost.xdt
-    - sed -i 's/v1_7_0/v0_1_41/g' $RELEASE_AGENT_DIR/datadog.yaml
-    - sed -i 's/v1_7_0/v0_1_41/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
-    - sed -i 's/v1.7.0/v0.1.41/g' $BASE_DIR/install.cmd
+    - echo "Updating versions from v1_8_0 to v0_1_42 for testing package"
+    - sed -i 's/v1_8_0/v0_1_42/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/EXTENSION_VERSION" value="1.8.0"/EXTENSION_VERSION" value="0.1.42"/g' dotnet/content/applicationHost.xdt
+    - sed -i 's/v1_8_0/v0_1_42/g' $RELEASE_AGENT_DIR/datadog.yaml
+    - sed -i 's/v1_8_0/v0_1_42/g' $RELEASE_AGENT_DIR/dogstatsd.yaml
+    - sed -i 's/v1.8.0/v0.1.42/g' $BASE_DIR/install.cmd
     - echo "Updating paths from Datadog.AzureAppServices.DotNet to DevelopmentVerification.DdDotNet.Apm for testing package"
     - sed -i 's/Datadog.AzureAppServices.DotNet/DevelopmentVerification.DdDotNet.Apm/g' $BASE_DIR/applicationHost.xdt
     - mkdir $DEVELOPMENT_DIR

--- a/dotnet/Datadog.AzureAppServices.DotNet.nuspec
+++ b/dotnet/Datadog.AzureAppServices.DotNet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Datadog.AzureAppServices.DotNet</id>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <title>.NET Datadog APM</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
+++ b/dotnet/DevelopmentVerification.DdDotNet.Apm.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>DevelopmentVerification.DdDotNet.Apm</id>
-    <version>0.1.41-prerelease</version>
+    <version>0.1.42-prerelease</version>
     <title>Experimental Extension</title>
     <authors>Datadog</authors>
     <icon>icon.png</icon>

--- a/dotnet/content/Agent/datadog.yaml
+++ b/dotnet/content/Agent/datadog.yaml
@@ -4,7 +4,7 @@ hostname: none
 enable_metadata_collection: false
 apm_config:
   enabled: true
-  log_file: D:\home\LogFiles\datadog\v1_7_0\trace-log.txt
+  log_file: D:\home\LogFiles\datadog\v1_8_0\trace-log.txt
 ## log_level: debug
 cloud_provider_metadata:
   - "azure"

--- a/dotnet/content/Agent/dogstatsd.yaml
+++ b/dotnet/content/Agent/dogstatsd.yaml
@@ -3,7 +3,7 @@ hostname: none
 ## disable sending the host metadata payload, required for serverless
 enable_metadata_collection: false
 use_dogstatsd: true
-log_file: D:\home\LogFiles\datadog\v1_7_0\dogstatsd.txt
+log_file: D:\home\LogFiles\datadog\v1_8_0\dogstatsd.txt
 ## log_level: debug
 cloud_provider_metadata:
   - "azure"

--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -47,24 +47,24 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\win-x86\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="DD_DOTNET_TRACER_HOME" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_INTEGRATIONS" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Tracer\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\v1_7_0\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOTNET_TRACER_HOME" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_INTEGRATIONS" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Tracer\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\v1_8_0\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_AGENT_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_TRACE_AGENT_ARGS" value="--config %HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_DOGSTATSD_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="DD_DOGSTATSD_ARGS" value="start -c %HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_7_0\Agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_AGENT_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_AGENT_ARGS" value="--config %HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOGSTATSD_PATH" value="%HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_DOGSTATSD_ARGS" value="start -c %HOME%\SiteExtensions\Datadog.AzureAppServices.DotNet\v1_8_0\Agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_TRACE_METRICS_ENABLED" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe;SnapshotUploader64.exe;Crashmon.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -79,7 +79,7 @@
 		
         <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port binding -->
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port binding -->
-        <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="1.7.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
+        <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="1.8.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
 
         <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
 

--- a/dotnet/content/install.cmd
+++ b/dotnet/content/install.cmd
@@ -3,7 +3,7 @@ REM Entrypoint: https://github.com/projectkudu/kudu/blob/13824205c60a4bdb53896b9
 
 @echo off
 
-set version=v1.7.0
+set version=v1.8.0
 set log_prefix=%date% %time% ^[%version%^]
 set log_file=..\..\Datadog.AzureAppServices.DotNet-Install.txt
 

--- a/set-dotnet-versions.bat
+++ b/set-dotnet-versions.bat
@@ -2,19 +2,19 @@ REM Set these version variables and run the script to change all the files which
 
 REM The site extension release version
 set major=1
-set minor=7
+set minor=8
 set patch=0
 set version_postfix=
 
 REM Specialized version for development package, increment as necessary for testing
 set development_minor=1
-set development_patch=41
+set development_patch=42
 
 REM The agent version to deploy (Manually including 7.30 pre-upload)
 set agent_version=7.31.1
 
 REM The dotnet tracer version to deploy
-set tracer_version=1.28.8
+set tracer_version=1.29.0
 
 REM **************************************************************************************************************************
 REM All of the below code updates versions in files, do not touch unless you wish to modify the structure of those files


### PR DESCRIPTION
.NET Release: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.29.0

- Updates the release version to 1.8.0
- Updates the development version to 0.1.42-prerelease