### PR TITLE
Enable java tracer and logging

### DIFF
--- a/java/build-packages.sh
+++ b/java/build-packages.sh
@@ -34,8 +34,10 @@ mv agent-extract/bin/agent/datadog-trace-agent.exe $RELEASE_AGENT_DIR
 echo "Versioning files"
 sed -i "s/vFOLDERUNKNOWN/v${RELEASE_VERSION_FILE}/g" java/content/applicationHost.xdt
 sed -i "s/vFOLDERUNKNOWN/v${RELEASE_VERSION_FILE}/g" java/content/install.cmd
+sed -i "s/vFOLDERUNKNOWN/v${RELEASE_VERSION_FILE}/g" java/content/install.ps1
 sed -i "s/vUNKNOWN/v${RELEASE_VERSION}/g" java/content/applicationHost.xdt
 sed -i "s/vUNKNOWN/v${RELEASE_VERSION}/g" java/content/install.cmd
+sed -i "s/vUNKNOWN/v${RELEASE_VERSION}/g" java/content/install.ps1
 
 echo "Creating nuget package"
 echo "Packing nuspec file via arcane roundabout csproj process"
@@ -45,8 +47,11 @@ echo "Updating versions from v${RELEASE_VERSION} to v${DEVELOPMENT_VERSION} for 
 sed -i "s/v${RELEASE_VERSION_FILE}/v${DEVELOPMENT_VERSION_FILE}/g" $RELEASE_AGENT_DIR/datadog.yaml
 sed -i "s/v${RELEASE_VERSION_FILE}/v${DEVELOPMENT_VERSION_FILE}/g" $RELEASE_AGENT_DIR/dogstatsd.yaml
 sed -i "s/v${RELEASE_VERSION_FILE}/v${DEVELOPMENT_VERSION_FILE}/g" java/content/applicationHost.xdt
+sed -i "s/v${RELEASE_VERSION_FILE}/v${DEVELOPMENT_VERSION_FILE}/g" $BASE_DIR/install.cmd
+sed -i "s/v${RELEASE_VERSION_FILE}/v${DEVELOPMENT_VERSION_FILE}/g" $BASE_DIR/install.ps1
 sed -i "s/v${RELEASE_VERSION}/v${DEVELOPMENT_VERSION}/g" java/content/applicationHost.xdt
 sed -i "s/v${RELEASE_VERSION}/v${DEVELOPMENT_VERSION}/g" $BASE_DIR/install.cmd
+sed -i "s/v${RELEASE_VERSION}/v${DEVELOPMENT_VERSION}/g" $BASE_DIR/install.ps1
 
 echo "Updating paths from Datadog.AzureAppServices.Java to DevelopmentVerification.DdJava.Apm for testing package"
 sed -i 's/Datadog.AzureAppServices.Java/DevelopmentVerification.DdJava.Apm/g' $BASE_DIR/applicationHost.xdt

--- a/java/content/applicationHost.xdt
+++ b/java/content/applicationHost.xdt
@@ -51,9 +51,9 @@
 
         <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
 		
-		<!-- TODO: Add Java Tracer Specific Variables -->
-        <add name="DD_JAVA_VARIABLE" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_JAVA_VARIABLE" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/> 
+		<!-- Java Tracer Specific Variables -->
+        <add name="JAVA_OPTS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="JAVA_OPTS" value="-javaagent:%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Tracer\dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.logFile=%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN\dd-java-agent.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
       </environmentVariables>
     </runtime>

--- a/java/content/install.ps1
+++ b/java/content/install.ps1
@@ -9,3 +9,6 @@ $tracePipeId=([guid]::NewGuid().ToString().ToUpper())
 $statsPipeId=([guid]::NewGuid().ToString().ToUpper())
 ((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueTracePipeId", "${tracePipeId}") | Set-Content -Path .\applicationHost.xdt
 ((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueStatsPipeId", "${statsPipeId}") | Set-Content -Path .\applicationHost.xdt
+
+# Create log directory ahead of time
+New-Item -ItemType Directory -Force -Path ${env:HOME}\LogFiles\datadog\java\vFOLDERUNKNOWN


### PR DESCRIPTION
Create logging directory ahead of time.
Add `JAVA_OPTS` with java tracer and log file.

![image](https://user-images.githubusercontent.com/1801443/139099031-76dfc47b-d431-48fb-91f5-b9d903d3ea45.png)
![image](https://user-images.githubusercontent.com/1801443/139099047-aaa7296d-20df-4d87-8fb8-f989eb90d186.png)
