### PR TITLE
Refactor install

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,6 +1,6 @@
 
 RELEASE_VERSION="1.8.0"
-DEVELOPMENT_VERSION="0.1.47-prerelease"
+DEVELOPMENT_VERSION="0.1.48-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.31.1-1-x86_64.zip" 
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.29.0/windows-tracer-home.zip"
 

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,6 +1,6 @@
 
 RELEASE_VERSION="1.8.0"
-DEVELOPMENT_VERSION="0.1.46-prerelease"
+DEVELOPMENT_VERSION="0.1.47-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.31.1-1-x86_64.zip" 
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.29.0/windows-tracer-home.zip"
 

--- a/dotnet/content/install.cmd
+++ b/dotnet/content/install.cmd
@@ -1,24 +1,4 @@
 
 REM Entrypoint: https://github.com/projectkudu/kudu/blob/13824205c60a4bdb53896b9553ef1f370a93b911/Kudu.Core/SiteExtensions/SiteExtensionManager.cs#L548
-
-@echo off
-
-set version=vUNKNOWN
-set log_prefix=%date% %time% ^[%version%^]
-set log_file=..\..\Datadog.AzureAppServices.DotNet-Install.txt
-
-echo %log_prefix% Starting install. >> %log_file%
-
-IF EXIST ..\Datadog.AzureAppServices\applicationHost.xdt (
-  echo %log_prefix% Datadog.AzureAppServices.DotNet can not be installed side by side with Datadog.AzureAppServices. >> %log_file%
-  exit /B 2
-)
-
-IF EXIST .\applicationHost.xdt (
-  echo %log_prefix% Upgrade will not apply until full application stop. >> %log_file%
-)
-
-POWERSHELL .\install.ps1 -ExtensionVersion %version%
-
-echo %log_prefix% Successfully installed. >> %log_file%
-exit /B 0
+set log_file=..\..\LogFiles\datadog\Datadog.AzureAppServices.DotNet-Install.txt
+POWERSHELL .\install.ps1 >> %log_file%

--- a/dotnet/content/install.ps1
+++ b/dotnet/content/install.ps1
@@ -4,22 +4,22 @@ $Version="vUNKNOWN"
 
 function Log ([string] $text)
 {
-    $LogDate=Get-Date -Format "MM/dd/yyyy HH:mm K"
+    $LogDate=Get-Date -Format "yyyy-MM-dd HH:mm K"
     Write-Output "[(${Version}) ${LogDate}] $text"
 }
 
 Log("Beginning install")
 
-function SetPipe ([string] $file, [string] $pipeName, [string] $pipeGuid)
+function SetPipe ([string] $file, [string] $pipePattern, [string] $pipeGuid)
 { 
-	if (Select-String -Path $file -Pattern $pipeName -SimpleMatch -Quiet)
+	if (Select-String -Path $file -Pattern $pipePattern -SimpleMatch -Quiet)
 	{
-		Log("Setting ${pipeName} to ${pipeGuid} in ${file}")
-		((Get-Content -path $file -Raw) -replace $pipeName, $pipeGuid) | Set-Content -Path $file
+		Log("Setting ${pipePattern} to ${pipeGuid} in ${file}")
+		((Get-Content -path $file -Raw) -replace $pipePattern, $pipeGuid) | Set-Content -Path $file
 	}
 	else
 	{
-		Log("${pipeName} has already been set in ${file}")
+		Log("${pipePattern} has already been set in ${file}")
 	}
 }
 
@@ -27,10 +27,10 @@ function SetPipe ([string] $file, [string] $pipeName, [string] $pipeGuid)
 $tracePipeId=([guid]::NewGuid().ToString().ToUpper())
 $statsPipeId=([guid]::NewGuid().ToString().ToUpper())
 
-SetPipe(".\applicationHost.xdt", "uniqueStatsPipeId", "${statsPipeId}")
-SetPipe(".\applicationHost.xdt", "uniqueTracePipeId", "${tracePipeId}")
-SetPipe(".\scmApplicationHost.xdt", "uniqueStatsPipeId", "${statsPipeId}")
-SetPipe(".\scmApplicationHost.xdt", "uniqueTracePipeId", "${tracePipeId}")
+SetPipe ".\applicationHost.xdt" "uniqueStatsPipeId" "${statsPipeId}"
+SetPipe ".\applicationHost.xdt" "uniqueTracePipeId" "${tracePipeId}"
+SetPipe ".\scmApplicationHost.xdt" "uniqueStatsPipeId" "${statsPipeId}"
+SetPipe ".\scmApplicationHost.xdt" "uniqueTracePipeId" "${tracePipeId}"
 
 if (Test-Path env:DD_AAS_REMOTE_INSTALL) {
     
@@ -65,11 +65,11 @@ if (Test-Path env:DD_AAS_REMOTE_INSTALL) {
     }
     
     Log("Installing specific commit: ${installSha}")
-    $latestHomeArtifactUrl="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${installSha}/tracer-home.zip"
+    $latestHomeArtifactUrl="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${installSha}/windows-tracer-home.zip"
     
     Invoke-RestMethod -Uri $latestHomeArtifactUrl -Method "GET" -OutFile "tracer-home.zip"
 
-    if (Test-Path "\tracer-home.zip") {
+    if (Test-Path -Path ".\tracer-home.zip") {
         Expand-Archive ".\tracer-home.zip" -DestinationPath ".\tracer-home\" -Force
     
         Remove-Item -Recurse -Force $tracerHome

--- a/dotnet/content/install.ps1
+++ b/dotnet/content/install.ps1
@@ -1,22 +1,46 @@
- param (
-    [Parameter(Mandatory=$true)][string]$ExtensionVersion
-)
-
 # https://github.com/projectkudu/kudu/blob/13824205c60a4bdb53896b9553ef1f370a93b911/Kudu.Services/SiteExtensions/SiteExtensionController.cs#L240
+
+$Version="vUNKNOWN"
+
+function Log ([string] $text)
+{
+    $LogDate=Get-Date -Format "MM/dd/yyyy HH:mm K"
+    Write-Output "[(${Version}) ${LogDate}] $text"
+}
+
+Log("Beginning install")
+
+function SetPipe ([string] $file, [string] $pipeName, [string] $pipeGuid)
+{ 
+	if (Select-String -Path $file -Pattern $pipeName -SimpleMatch -Quiet)
+	{
+		Log("Setting ${pipeName} to ${pipeGuid} in ${file}")
+		((Get-Content -path $file -Raw) -replace $pipeName, $pipeGuid) | Set-Content -Path $file
+	}
+	else
+	{
+		Log("${pipeName} has already been set in ${file}")
+	}
+}
 
 # Set the unique pipe names in the applicationHost.xdt file for traces and metrics
 $tracePipeId=([guid]::NewGuid().ToString().ToUpper())
 $statsPipeId=([guid]::NewGuid().ToString().ToUpper())
-((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueTracePipeId", "${tracePipeId}") | Set-Content -Path .\applicationHost.xdt
-((Get-Content -path .\applicationHost.xdt -Raw) -replace "uniqueStatsPipeId", "${statsPipeId}") | Set-Content -Path .\applicationHost.xdt
+
+SetPipe(".\applicationHost.xdt", "uniqueStatsPipeId", "${statsPipeId}")
+SetPipe(".\applicationHost.xdt", "uniqueTracePipeId", "${tracePipeId}")
+SetPipe(".\scmApplicationHost.xdt", "uniqueStatsPipeId", "${statsPipeId}")
+SetPipe(".\scmApplicationHost.xdt", "uniqueTracePipeId", "${tracePipeId}")
 
 if (Test-Path env:DD_AAS_REMOTE_INSTALL) {
     
+    Log("Installing from remote source: $env:DD_AAS_REMOTE_INSTALL")
+
     # https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/77#issuecomment-601947496
     # Global is required because Expand-Archive module calls ignore the contextual $ProgressPreference
     $global:ProgressPreference = "SilentlyContinue"
     
-    $underscoreVersion=($ExtensionVersion -replace "\.", "_")
+    $underscoreVersion="vFOLDERUNKNOWN"
     $tracerHome="${PSScriptRoot}\${underscoreVersion}\Tracer"
     
     # View available artifacts: 
@@ -40,20 +64,30 @@ if (Test-Path env:DD_AAS_REMOTE_INSTALL) {
         $installSha=$installOption
     }
     
-    $latestHomeArtifactUrl="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${installSha}/windows-tracer-home.zip"
+    Log("Installing specific commit: ${installSha}")
+    $latestHomeArtifactUrl="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${installSha}/tracer-home.zip"
     
     Invoke-RestMethod -Uri $latestHomeArtifactUrl -Method "GET" -OutFile "tracer-home.zip"
 
-    Expand-Archive ".\tracer-home.zip" -DestinationPath ".\tracer-home\" -Force
-
-    Remove-Item -Recurse -Force $tracerHome
-    mkdir $tracerHome
-    Get-ChildItem -Path ".\tracer-home\*" -Recurse | Move-Item -Destination "$tracerHome"
-
-    Remove-Item -Recurse -Force ".\tracer-home"
-    Remove-Item -Recurse ".\tracer-home.zip"
-
-    $extensionVersionReplace="DD_AAS_DOTNET_EXTENSION_VERSION"" value=""${installSha}"""
-
-    ((Get-Content -path .\applicationHost.xdt -Raw) -replace 'DD_AAS_DOTNET_EXTENSION_VERSION" value="[^"]+"', $extensionVersionReplace) | Set-Content -Path .\applicationHost.xdt
+    if (Test-Path "\tracer-home.zip") {
+        Expand-Archive ".\tracer-home.zip" -DestinationPath ".\tracer-home\" -Force
+    
+        Remove-Item -Recurse -Force $tracerHome
+        mkdir $tracerHome
+        Get-ChildItem -Path ".\tracer-home\*" -Recurse | Move-Item -Destination "$tracerHome"
+    
+        Remove-Item -Recurse -Force ".\tracer-home"
+        Remove-Item -Recurse ".\tracer-home.zip"
+    
+        $extensionVersionReplace="DD_AAS_DOTNET_EXTENSION_VERSION"" value=""${installSha}"""
+    
+        ((Get-Content -path .\applicationHost.xdt -Raw) -replace 'DD_AAS_DOTNET_EXTENSION_VERSION" value="[^"]+"', $extensionVersionReplace) | Set-Content -Path .\applicationHost.xdt
+        
+        Log("Replaced tracer: ${installSha}")
+    }
+    else {
+        Log("Failed to download and replace tracer: ${installSha}")
+    }
 }
+
+Log("Install complete")

--- a/dotnet/content/scmApplicationHost.xdt
+++ b/dotnet/content/scmApplicationHost.xdt
@@ -2,4 +2,16 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <!-- This file exists to prevent applicationHost.xdt from being applied to scm host that runs
       other dotnet processes (dotnet build, csc etc. )-->
+	<environmentVariables xdt:Transform="InsertIfMissing">
+        
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
+        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
+        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
+
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
 </configuration>

--- a/dotnet/content/scmApplicationHost.xdt
+++ b/dotnet/content/scmApplicationHost.xdt
@@ -3,12 +3,22 @@
   <!-- This file exists to prevent applicationHost.xdt from being applied to scm host that runs
       other dotnet processes (dotnet build, csc etc. )-->
 	<environmentVariables xdt:Transform="InsertIfMissing">
+	
+		<!-- These variables enable manual tracing and custom metrics from web jobs in the scm context -->
         
-        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
-        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Trace server variable -->
+		
+        <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Trace client variable -->
 
+        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
+		
+        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
+		
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
 
       </environmentVariables>


### PR DESCRIPTION
 - Installer log is consolidated in datadog log files directory
 - Remove logging logic from `install.cmd`
 - Implement https://github.com/DataDog/datadog-aas-extension/issues/48
 - Better logging for diagnosing install problems