### PR TITLE
Upgrade agent to 7.32.0

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,7 +1,7 @@
 
 RELEASE_VERSION="1.8.0"
-DEVELOPMENT_VERSION="0.1.48-prerelease"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.31.1-1-x86_64.zip" 
+DEVELOPMENT_VERSION="0.1.49-prerelease"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.0-1-x86_64.zip" 
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.29.0/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"

--- a/java/build-packages.sh
+++ b/java/build-packages.sh
@@ -1,7 +1,7 @@
 
 RELEASE_VERSION="0.1.0"
-DEVELOPMENT_VERSION="0.1.2-prerelease"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.31.1-1-x86_64.zip" 
+DEVELOPMENT_VERSION="0.1.3-prerelease"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.0-1-x86_64.zip" 
 TRACER_DOWNLOAD_URL="https://225900-89221572-gh.circle-artifacts.com/0/libs/dd-java-agent-0.90.0-SNAPSHOT.jar"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent/releases/tag/7.32.0

Lots of features/fixes

```
...
APM: New telemetry was added to measure /v.*/traces endpoints latency and response size. These metrics are datadog.trace_agent.receiver.{rate_response_bytes,serve_traces_ms}.
APM: Metrics are now available for Windows Pipes and UDS connections via datadog.trace_agent.receiver {uds_connections,pipe_connections}.
...
```

Very importantly:
`Make sure DD_ENABLE_METADATA_COLLECTION="false" prevent all host metadata emission, including the initial one.`