### PR TITLE
Add mkdir to install

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,6 +1,6 @@
 
 RELEASE_VERSION="1.9.0"
-DEVELOPMENT_VERSION="0.1.51-prerelease"
+DEVELOPMENT_VERSION="0.1.52-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.0-1-x86_64.zip" 
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.30.0/windows-tracer-home.zip"
 

--- a/dotnet/content/install.cmd
+++ b/dotnet/content/install.cmd
@@ -1,4 +1,5 @@
 
 REM Entrypoint: https://github.com/projectkudu/kudu/blob/13824205c60a4bdb53896b9553ef1f370a93b911/Kudu.Core/SiteExtensions/SiteExtensionManager.cs#L548
+mkdir ..\..\LogFiles\datadog
 set log_file=..\..\LogFiles\datadog\Datadog.AzureAppServices.DotNet-Install.txt
 POWERSHELL .\install.ps1 >> %log_file%


### PR DESCRIPTION
Installation script can fail if the directory does not exist.
This happens particularly on applications with deployment slots.