### PR TITLE
Bump dotnet tracer version to 1.30.1

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,8 +1,8 @@
 
-RELEASE_VERSION="1.9.1"
-DEVELOPMENT_VERSION="0.1.52-prerelease"
+RELEASE_VERSION="1.9.2"
+DEVELOPMENT_VERSION="0.1.53-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.0-1-x86_64.zip" 
-TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.30.0/windows-tracer-home.zip"
+TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.30.1/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"
 wget -O tracer.zip $TRACER_DOWNLOAD_URL


### PR DESCRIPTION
.NET Release: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.30.1

Updates the release version to 1.9.2
Updates the development version to 0.1.53-prerelease