### PR TITLE
Bump version 1 of the tracer

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,8 +1,8 @@
 
-RELEASE_VERSION="1.10.1"
+RELEASE_VERSION="1.10.2"
 DEVELOPMENT_VERSION="0.1.56-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.3-1-x86_64.zip"
-TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.0.1/windows-tracer-home.zip"
+TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.31.1/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"
 wget -O tracer.zip $TRACER_DOWNLOAD_URL

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,6 +1,6 @@
 
 RELEASE_VERSION="1.10.2"
-DEVELOPMENT_VERSION="0.1.56-prerelease"
+DEVELOPMENT_VERSION="0.1.57-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.3-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v1.31.1/windows-tracer-home.zip"
 


### PR DESCRIPTION
The .Net tracer v1 will now be bump on the release/1.x branch, as we do on dd-trace-dotnet