### PR TITLE
First step of release automation

### DIFF
--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           VERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
           TAGNAME=dotnet-v$VERSION
+          echo "::set-output name=tagname::$TAGNAME"
+          echo "::set-output name=version::$VERSION"
           git tag "$TAGNAME"
           git push origin "$TAGNAME"
 
@@ -31,7 +33,27 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          name: "$TAGNAME"
-          tag_name: "$TAGNAME"
+          name: "${{steps.version.outputs.tagname}}"
+          tag_name: "${{steps.version.outputs.tagname}}"
           prerelease: false
-          body: "copy paste from the previous release"
+          body: |
+          
+          ## Versions included
+          [.NET Tracer v${{steps.version.outputs.version}}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v${{steps.version.outputs.version}})
+          [Datadog Agent v7.32.4](https://github.com/DataDog/datadog-agent/releases/tag/7.32.4)
+          
+          Hosted on [Nuget](https://www.nuget.org/packages/Datadog.AzureAppServices.DotNet/${{steps.version.outputs.version}})
+          
+          [Site Extension Documentation](https://docs.datadoghq.com/serverless/azure_app_services/)
+          
+          ## Requirements
+          The .NET Datadog APM Site Extension requires that you setup the [Microsoft Azure Integration](https://docs.datadoghq.com/integrations/azure_app_services/) first.
+          Please follow the directions in the referenced document.
+          
+          ## .NET Core Installation and Upgrade
+          Install or upgrade the site extension, and verify traces and metrics.
+          
+          ## .NET Framework Installation and Upgrade
+          Fully stop your web app before installing, modifying, or removing the .NET Datadog APM Site Extension.
+          This site extension uses the [.NET Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-interfaces) which hooks in at process start.
+          *Restart* recycles an application pool, the app must be *STOPPED* before any changes to this extension.

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -24,9 +24,11 @@ jobs:
           VERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
           TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v[0-9]*\.[0-9]*\.[0-9]* dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
           TAGNAME=dotnet-v$VERSION
+          AGENT_VERSION="$(grep -o -e agent-binaries-[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
           echo "::set-output name=tagname::$TAGNAME"
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=tracer_version::$TRACER_VERSION"
+          echo "::set-output name=agent_version::$AGENT_VERSION"
           git tag "$TAGNAME"
           git push origin "$TAGNAME"
       - name: Create Release
@@ -39,7 +41,7 @@ jobs:
           body: |
             ## Versions included
             [.NET Tracer v${{steps.version.outputs.tracer_version}}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v${{steps.version.outputs.tracer_version}})
-            [Datadog Agent v7.32.4](https://github.com/DataDog/datadog-agent/releases/tag/7.32.4)
+            [Datadog Agent v${{steps.version.outputs.agent_version}}](https://github.com/DataDog/datadog-agent/releases/tag/{{steps.version.outputs.agent_version}})
             Hosted on [Nuget](https://www.nuget.org/packages/Datadog.AzureAppServices.DotNet/${{steps.version.outputs.version}})
             [Site Extension Documentation](https://docs.datadoghq.com/serverless/azure_app_services/)
             ## Requirements

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -1,0 +1,37 @@
+name: Auto tag version bump commit and create release
+
+on:
+  push:
+    branches: [ master]
+    tags-ignore:
+      - '**'
+
+jobs:
+  tag_version_bump_commit:
+    if: startsWith(github.event.head_commit.message, '[Version Bump]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: "Create and push git tag"
+        id: version
+        run: |
+          VERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
+          TAGNAME=dotnet-v$VERSION
+          git tag "$TAGNAME"
+          git push origin "$TAGNAME"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: "$TAGNAME"
+          tag_name: "$TAGNAME"
+          prerelease: false
+          body: "copy paste from the previous release"

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -2,13 +2,13 @@ name: Auto tag version bump commit and create release
 
 on:
   push:
-    branches: [ master]
+    branches: [ master, main, release/*, hotfix/* ]
     tags-ignore:
       - '**'
 
 jobs:
   tag_version_bump_commit:
-    if: startsWith(github.event.head_commit.message, '[Version Bump]')
+    if: startsWith(github.event.head_commit.message, '[.Net Version Bump]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,17 +18,17 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
       - name: "Create and push git tag"
         id: version
         run: |
           VERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
+          TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v[0-9]*\.[0-9]*\.[0-9]* dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
           TAGNAME=dotnet-v$VERSION
           echo "::set-output name=tagname::$TAGNAME"
           echo "::set-output name=version::$VERSION"
+          echo "::set-output name=tracer_version::$TRACER_VERSION"
           git tag "$TAGNAME"
           git push origin "$TAGNAME"
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -37,23 +37,17 @@ jobs:
           tag_name: "${{steps.version.outputs.tagname}}"
           prerelease: false
           body: |
-          
-          ## Versions included
-          [.NET Tracer v${{steps.version.outputs.version}}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v${{steps.version.outputs.version}})
-          [Datadog Agent v7.32.4](https://github.com/DataDog/datadog-agent/releases/tag/7.32.4)
-          
-          Hosted on [Nuget](https://www.nuget.org/packages/Datadog.AzureAppServices.DotNet/${{steps.version.outputs.version}})
-          
-          [Site Extension Documentation](https://docs.datadoghq.com/serverless/azure_app_services/)
-          
-          ## Requirements
-          The .NET Datadog APM Site Extension requires that you setup the [Microsoft Azure Integration](https://docs.datadoghq.com/integrations/azure_app_services/) first.
-          Please follow the directions in the referenced document.
-          
-          ## .NET Core Installation and Upgrade
-          Install or upgrade the site extension, and verify traces and metrics.
-          
-          ## .NET Framework Installation and Upgrade
-          Fully stop your web app before installing, modifying, or removing the .NET Datadog APM Site Extension.
-          This site extension uses the [.NET Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-interfaces) which hooks in at process start.
-          *Restart* recycles an application pool, the app must be *STOPPED* before any changes to this extension.
+            ## Versions included
+            [.NET Tracer v${{steps.version.outputs.tracer_version}}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v${{steps.version.outputs.tracer_version}})
+            [Datadog Agent v7.32.4](https://github.com/DataDog/datadog-agent/releases/tag/7.32.4)
+            Hosted on [Nuget](https://www.nuget.org/packages/Datadog.AzureAppServices.DotNet/${{steps.version.outputs.version}})
+            [Site Extension Documentation](https://docs.datadoghq.com/serverless/azure_app_services/)
+            ## Requirements
+            The .NET Datadog APM Site Extension requires that you setup the [Microsoft Azure Integration](https://docs.datadoghq.com/integrations/azure_app_services/) first.
+            Please follow the directions in the referenced document.
+            ## .NET Core Installation and Upgrade
+            Install or upgrade the site extension, and verify traces and metrics.
+            ## .NET Framework Installation and Upgrade
+            Fully stop your web app before installing, modifying, or removing the .NET Datadog APM Site Extension.
+            This site extension uses the [.NET Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-interfaces) which hooks in at process start.
+            *Restart* recycles an application pool, the app must be *STOPPED* before any changes to this extension.

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -28,8 +28,6 @@ jobs:
           CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
           VERSION="${{ github.event.inputs.version }}"
           sed -i '' -e "s/$CURRENTVERSION/"$VERSION/g" dotnet/build-packages.sh
-          git tag "$TAGNAME"
-          git push origin "$TAGNAME"
 
       - name: Create Pull Request
         id: pr

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -68,13 +68,13 @@ jobs:
             echo Bumping tracer version to $TRACER_VERSION
             sed -i -e "s#dd-trace-dotnet/releases/download/v$CURRENT_TRACER_VERSION#dd-trace-dotnet/releases/download/v$TRACER_VERSION#" dotnet/build-packages.sh
             echo Replaced release version in file.
-            PR_BODY="$PR_BODY Also updates the tracer url to use the last version of the .net Tracer: $TRACER_VERSION"
+            PR_BODY="$PR_BODY\nAlso updates the tracer url to use the last version of the .NET Tracer: $TRACER_VERSION"
           fi
 
           CURRENT_AGENT_VERSION="$(grep -o -e agent-binaries-[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
           AGENT_VERSION=${{ steps.last_release.outputs.release }}
           echo Current agent version is: $CURRENT_AGENT_VERSION
-          echo "Last Agent version: $AGENT_VERSION"
+          echo "Latest Agent version: $AGENT_VERSION"
 
           major=0
           minor=0
@@ -97,19 +97,19 @@ jobs:
           fi
 
           if [[ $agent_major > $major ]]; then
-            updateTracer = 1
+            updateAgent=1
           elif [[ $agent_minor > $minor ]]; then
-            updateTracer = 1
+            updateAgent=1
           elif [[ $agent_build > $build ]]; then
-            updateTracer = 1
+            updateAgent=1
           fi
 
-          if [[ $updateTracer == 1 ]]; then
+          if [[ "$updateAgent" == "1" ]]; then
             echo Updating agent version
             
             sed -i -e "s/agent-binaries-$CURRENT_AGENT_VERSION/agent-binaries-$AGENT_VERSION/" dotnet/build-packages.sh
             echo Replaced agent version in file.
-            PR_BODY="$PR_BODY Also updates the agent url to use the last version: $AGENT_VERSION"
+            PR_BODY="$PR_BODY\nAlso updates the agent URL to use the latest version: $AGENT_VERSION"
           fi
 
           echo "::set-output name=version::$VERSION"

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Next Version Number (x.x.x)'
+        description: 'Next Version Number (x.y.zzz).'
         required: true
-      is_prerelease:
-        description: 'Is Prerelease version? (true/false)'
-        default: 'false'
-        required: true
+      tracer_version:
+        description: 'Next Version Number (x.y.z). To be used for a tracer version bump.'
+        required: false
 
 jobs:
   bump_version:
@@ -24,21 +23,43 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Modify build-packages"
+        id: "versions"
         run: |
           CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
-          VERSION="${{ github.event.inputs.version }}"
-          sed -i '' -e "s/$CURRENTVERSION/"$VERSION/g" dotnet/build-packages.sh
-
+          echo Current version is: $CURRENTVERSION
+          
+          VERSION=${{ github.event.inputs.version }}
+          echo Bumping extension version to $VERSION
+          
+          sed -i -e "s/RELEASE_VERSION=\"$CURRENTVERSION\"/RELEASE_VERSION=\"$VERSION\"/g" dotnet/build-packages.sh
+          echo Replaced release version in file.
+          PR_BODY="Bumps the release version to $VERSION."
+          
+          TRACER_VERSION=${{ github.event.inputs.tracer_version }}
+          if [ -n "$TRACER_VERSION" ]; then
+            CURRENT_TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v[0-9]*\.[0-9]*\.[0-9]* dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
+            echo Current tracer version is: $CURRENT_TRACER_VERSION
+            
+            echo Bumping tracer version to $TRACER_VERSION
+            sed -i -e "s#dd-trace-dotnet/releases/download/v$CURRENT_TRACER_VERSION#dd-trace-dotnet/releases/download/v$TRACER_VERSION#" dotnet/build-packages.sh
+            echo Replaced release version in file.
+            PR_BODY="$PR_BODY Also updates the tracer url to use the last version of the .net Tracer: $TRACER_VERSION"
+          fi
+          
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=tracer_version::$TRACER_VERSION"
+          echo "::set-output name=pr_body::$PR_BODY"
+          
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@v3.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "version-bump-${{steps.versions.outputs.full_version}}"
-          commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          branch: "version-bump-${{steps.versions.outputs.version}}"
+          commit-message: "[.Net Version Bump] Bump to v${{steps.versions.outputs.version}}"
           delete-branch: true
-          title: "[Version Bump] ${{steps.versions.outputs.full_version}}"
-          body: "Dotnet Tracer Bump"
+          title: "[.Net Version Bump] Bump to v${{steps.versions.outputs.version}}"
+          body: "${{steps.versions.outputs.pr_body}}"
 
       - name: Display output
         run: |

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -22,17 +22,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: "Get last agent release"
+        id: last_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: DataDog
+          repo: datadog-agent
+          excludes: prerelease, draft
+
       - name: "Modify build-packages"
         id: "versions"
         run: |
           CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
           echo Current version is: $CURRENTVERSION
-          
+          CURRENT_DEV_VERSION="$(grep -o -e DEVELOPMENT_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/DEVELOPMENT_VERSION="//')"
+          echo Current dev version is: $CURRENT_DEV_VERSION
+
           VERSION=${{ github.event.inputs.version }}
           echo Bumping extension version to $VERSION
-          
+
           sed -i -e "s/RELEASE_VERSION=\"$CURRENTVERSION\"/RELEASE_VERSION=\"$VERSION\"/g" dotnet/build-packages.sh
           echo Replaced release version in file.
+          major=0
+          minor=0
+          build=0
+          # break down the version number into it's components
+          regex="([0-9]+).([0-9]+).([0-9]+)"
+          if [[ $CURRENT_DEV_VERSION =~ $regex ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            build="${BASH_REMATCH[3]}"
+          fi
+          DEV_VERSION=$major.$minor.$(echo $build+1 | bc)
+          echo New dev version is $DEV_VERSION
+          sed -i -e "s/DEVELOPMENT_VERSION=\"$CURRENT_DEV_VERSION/DEVELOPMENT_VERSION=\"$DEV_VERSION/g" dotnet/build-packages.sh
+          echo Replaced dev version in file.
+          
           PR_BODY="Bumps the release version to $VERSION."
           
           TRACER_VERSION=${{ github.event.inputs.tracer_version }}
@@ -45,7 +70,48 @@ jobs:
             echo Replaced release version in file.
             PR_BODY="$PR_BODY Also updates the tracer url to use the last version of the .net Tracer: $TRACER_VERSION"
           fi
-          
+
+          CURRENT_AGENT_VERSION="$(grep -o -e agent-binaries-[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
+          AGENT_VERSION=${{ steps.last_release.outputs.release }}
+          echo Current agent version is: $CURRENT_AGENT_VERSION
+          echo "Last Agent version: $AGENT_VERSION"
+
+          major=0
+          minor=0
+          build=0
+          agent_major=0
+          agent_minor=0
+          agent_build=0
+          # break down the version number into it's components
+          regex="([0-9]+).([0-9]+).([0-9]+)"
+          if [[ $CURRENT_AGENT_VERSION =~ $regex ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            build="${BASH_REMATCH[3]}"
+          fi
+          regex="([0-9]+).([0-9]+).([0-9]+)"
+          if [[ $AGENT_VERSION =~ $regex ]]; then
+            agent_major="${BASH_REMATCH[1]}"
+            agent_minor="${BASH_REMATCH[2]}"
+            agent_build="${BASH_REMATCH[3]}"
+          fi
+
+          if [[ $agent_major > $major ]]; then
+            updateTracer = 1
+          elif [[ $agent_minor > $minor ]]; then
+            updateTracer = 1
+          elif [[ $agent_build > $build ]]; then
+            updateTracer = 1
+          fi
+
+          if [[ $updateTracer == 1 ]]; then
+            echo Updating agent version
+            
+            sed -i -e "s/agent-binaries-$CURRENT_AGENT_VERSION/agent-binaries-$AGENT_VERSION/" dotnet/build-packages.sh
+            echo Replaced agent version in file.
+            PR_BODY="$PR_BODY Also updates the agent url to use the last version: $AGENT_VERSION"
+          fi
+
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=tracer_version::$TRACER_VERSION"
           echo "::set-output name=pr_body::$PR_BODY"

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -1,0 +1,48 @@
+name: Create version bump PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Next Version Number (x.x.x)'
+        required: true
+      is_prerelease:
+        description: 'Is Prerelease version? (true/false)'
+        default: 'false'
+        required: true
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      Version: "${{ github.event.inputs.version }}"
+      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: "Modify build-packages"
+        run: |
+          CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
+          VERSION="${{ github.event.inputs.version }}"
+          sed -i '' -e "s/$CURRENTVERSION/"$VERSION/g" dotnet/build-packages.sh
+          git tag "$TAGNAME"
+          git push origin "$TAGNAME"
+
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "version-bump-${{steps.versions.outputs.full_version}}"
+          commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          delete-branch: true
+          title: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          body: "Dotnet Tracer Bump"
+
+      - name: Display output
+        run: |
+          echo "Pull Request Number - ${{ steps.pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}"

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -33,9 +33,13 @@ jobs:
       - name: "Modify build-packages"
         id: "versions"
         run: |
-          CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
+          versionRegex="[0-9]*.[0-9]*.[0-9]*"
+          splitVersionRegex="([0-9]+).([0-9]+).([0-9]+)"
+
+          CURRENTVERSION="$(grep -o -e RELEASE_VERSION\=\"$versionRegex dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
           echo Current version is: $CURRENTVERSION
-          CURRENT_DEV_VERSION="$(grep -o -e DEVELOPMENT_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/DEVELOPMENT_VERSION="//')"
+
+          CURRENT_DEV_VERSION="$(grep -o -e DEVELOPMENT_VERSION\=\"$versionRegex dotnet/build-packages.sh | sed 's/DEVELOPMENT_VERSION="//')"
           echo Current dev version is: $CURRENT_DEV_VERSION
 
           VERSION=${{ github.event.inputs.version }}
@@ -43,35 +47,37 @@ jobs:
 
           sed -i -e "s/RELEASE_VERSION=\"$CURRENTVERSION\"/RELEASE_VERSION=\"$VERSION\"/g" dotnet/build-packages.sh
           echo Replaced release version in file.
+
           major=0
           minor=0
           build=0
-          # break down the version number into it's components
-          regex="([0-9]+).([0-9]+).([0-9]+)"
-          if [[ $CURRENT_DEV_VERSION =~ $regex ]]; then
+
+          if [[ $CURRENT_DEV_VERSION =~ $splitVersionRegex ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             build="${BASH_REMATCH[3]}"
           fi
+
           DEV_VERSION=$major.$minor.$(echo $build+1 | bc)
           echo New dev version is $DEV_VERSION
+
           sed -i -e "s/DEVELOPMENT_VERSION=\"$CURRENT_DEV_VERSION/DEVELOPMENT_VERSION=\"$DEV_VERSION/g" dotnet/build-packages.sh
           echo Replaced dev version in file.
-          
+
           PR_BODY="Bumps the release version to $VERSION."
-          
+
           TRACER_VERSION=${{ github.event.inputs.tracer_version }}
           if [ -n "$TRACER_VERSION" ]; then
-            CURRENT_TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v[0-9]*\.[0-9]*\.[0-9]* dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
+            CURRENT_TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v$versionRegex dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
             echo Current tracer version is: $CURRENT_TRACER_VERSION
-            
+  
             echo Bumping tracer version to $TRACER_VERSION
             sed -i -e "s#dd-trace-dotnet/releases/download/v$CURRENT_TRACER_VERSION#dd-trace-dotnet/releases/download/v$TRACER_VERSION#" dotnet/build-packages.sh
             echo Replaced release version in file.
             PR_BODY="$PR_BODY\nAlso updates the tracer url to use the last version of the .NET Tracer: $TRACER_VERSION"
           fi
 
-          CURRENT_AGENT_VERSION="$(grep -o -e agent-binaries-[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
+          CURRENT_AGENT_VERSION="$(grep -o -e agent-binaries-$versionRegex  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
           AGENT_VERSION=${{ steps.last_release.outputs.release }}
           echo Current agent version is: $CURRENT_AGENT_VERSION
           echo "Latest Agent version: $AGENT_VERSION"
@@ -82,15 +88,13 @@ jobs:
           agent_major=0
           agent_minor=0
           agent_build=0
-          # break down the version number into it's components
-          regex="([0-9]+).([0-9]+).([0-9]+)"
-          if [[ $CURRENT_AGENT_VERSION =~ $regex ]]; then
+          if [[ $CURRENT_AGENT_VERSION =~ $splitVersionRegex ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             build="${BASH_REMATCH[3]}"
           fi
-          regex="([0-9]+).([0-9]+).([0-9]+)"
-          if [[ $AGENT_VERSION =~ $regex ]]; then
+
+          if [[ $AGENT_VERSION =~ $splitVersionRegex ]]; then
             agent_major="${BASH_REMATCH[1]}"
             agent_minor="${BASH_REMATCH[2]}"
             agent_build="${BASH_REMATCH[3]}"
@@ -106,7 +110,7 @@ jobs:
 
           if [[ "$updateAgent" == "1" ]]; then
             echo Updating agent version
-            
+  
             sed -i -e "s/agent-binaries-$CURRENT_AGENT_VERSION/agent-binaries-$AGENT_VERSION/" dotnet/build-packages.sh
             echo Replaced agent version in file.
             PR_BODY="$PR_BODY\nAlso updates the agent URL to use the latest version: $AGENT_VERSION"
@@ -115,7 +119,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=tracer_version::$TRACER_VERSION"
           echo "::set-output name=pr_body::$PR_BODY"
-          
+
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@v3.10.0


### PR DESCRIPTION
Reuse what we used to have in dd-trace-dotnet ie a Version Bump action and an automatic tagging one. Here's how it works.
The Version Bump:
- takes the new version in input
- replaces the version
- creates a PR

The automatic one will:
- trigger when the version bump is merged
- apply the tag
- open a draft release

I have made here two postulates. First, I don't want to rely on Nuke. Indeed, I want the Java team, or any team that would take ownership to easily own this process. 
Also, from now on, AAS extension versions will follow the pattern: `{major}.{minor}.{patch}{toolsVersion}` to follow the .Net Tracer version. This will allow to follow the .Net Tracer version while allowing for extension upgrades.

Outstanding work:
- [x] Update the dev package version
- [x] Fill the body of the release
- [x] Update the agent version

Next Steps (in other PRs):
- [ ] Call from dd-trace-dotnet the version bump action
- [ ] Upload nugets to nuget.org

AIT-372