### PR TITLE
Upgrade .net  dev version after tests on nuget.org

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,6 +1,6 @@
 
 RELEASE_VERSION="2.2.100"
-DEVELOPMENT_VERSION="0.1.61-prerelease"
+DEVELOPMENT_VERSION="0.2.100-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.32.4-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.2.0/windows-tracer-home.zip"
 


### PR DESCRIPTION
I ran tests around the versioning scheme so I increased the last version of the dev package on nuget.
This is to make it equivalent to the last version on nuget.org