### PR TITLE
Fix SCM xdt file

### DIFF
--- a/dotnet/content/scmApplicationHost.xdt
+++ b/dotnet/content/scmApplicationHost.xdt
@@ -1,26 +1,9 @@
 ﻿<?xml version="1.0"?>
+<!-- This file exists to prevent applicationHost.xdt from being applied to scm host that runs other dotnet processes (dotnet build, csc etc. )-->
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <!-- This file exists to prevent applicationHost.xdt from being applied to scm host that runs
-      other dotnet processes (dotnet build, csc etc. )-->
-	<environmentVariables xdt:Transform="InsertIfMissing">
-	
-		<!-- These variables enable manual tracing and custom metrics from web jobs in the scm context -->
-        
-        <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Trace server variable -->
-		
-        <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Trace client variable -->
-
-        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
-		
-        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
-		
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
-
+  <system.webServer>
+    <runtime xdt:Transform="InsertIfMissing" >
+      <environmentVariables xdt:Transform="InsertIfMissing">
       </environmentVariables>
     </runtime>
   </system.webServer>


### PR DESCRIPTION
The transformation file used for the scm website was broken.
This led to error logs in the `Transform` folder in AAS, even though not breaking.

There's another PR #111, to improve it and enable webjobs, but I haven't been able to make it work yet surprisingly.

