### PR TITLE
Start improving local deployments 

### DIFF
--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -32,33 +32,12 @@ jobs:
       - name: "Modify build-packages-dev"
         id: "versions"
         run: |
-          versionRegex="[0-9]*.[0-9]*.[0-9]*"
-          splitVersionRegex="([0-9]+).([0-9]+).([0-9]+)"
-
-          CURRENT_DEV_VERSION="$(grep -o -e DEVELOPMENT_VERSION\=\"$versionRegex dotnet/build-packages-dev.sh | sed 's/DEVELOPMENT_VERSION="//')"
-          echo Current dev version is: $CURRENT_DEV_VERSION
-
-          major=0
-          minor=0
           build=${{ github.run_id }}
           build="${build:1}"
 
-          if [[ $CURRENT_DEV_VERSION =~ $splitVersionRegex ]]; then
-            major="${BASH_REMATCH[1]}"
-            minor="${BASH_REMATCH[2]}"
-          fi
-
-          DEV_VERSION=$major.$minor.$(echo $build | bc)
+          DEV_VERSION=0.2.$(echo $build | bc)
           echo New dev version is $DEV_VERSION
           echo "::set-output name=dev_version::$DEV_VERSION"
-
-          sed -i -e "s/DEVELOPMENT_VERSION=\"$CURRENT_DEV_VERSION/DEVELOPMENT_VERSION=\"$DEV_VERSION/g" dotnet/build-packages-dev.sh
-          echo Replaced dev version in file.
-
-          sha=${{ steps.set_variables.outputs.sha }}
-          echo Setting install sha to $sha
-          sed -i -e "s/INSTALL_SHA/$sha/g" dotnet/build-packages-dev.sh
-          echo Replaced install sha in file.
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -66,14 +45,15 @@ jobs:
 
       - name: "Build nuget package"
         run: |
-          bash dotnet/build-packages-dev.sh
+          sha=${{ steps.set_variables.outputs.sha }}
+          dev_version=${{steps.versions.outputs.dev_version}}
+
+          bash dotnet/build-packages-dev.sh $dev_version $sha
 
       - name: "Upload dev nuget"
         run: |
-          dotnet nuget add source https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json --name Public_Feed --username any_string --password ${{ secrets.AZDO_PAT }} --store-password-in-clear-text
-
-          dev_version="${{steps.versions.outputs.dev_version}}-prerelease"
-          dotnet nuget push package/DevelopmentVerification.DdDotNet.Apm.$dev_version.nupkg --source Public_Feed --api-key any_string
+          dev_version=${{steps.versions.outputs.dev_version}}
+          bash dotnet/upload-dev-nuget.sh $dev_version ${{ secrets.AZDO_PAT }}
 
       - name: Azure CLI script
         uses: azure/CLI@v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@ content.zip
 obj/
 /set-versions-log.txt
 /bin/*
-/dotnet/content/Tracer/*
+/dotnet-agent-extract
 /dotnet/content/Agent/dogstatsd.exe
 /dotnet/content/Agent/datadog-trace-agent.exe
+/dotnet/content/v*
+/dotnet/content/Tracer/*
 /package/*
+*.zip

--- a/dotnet/README.MD
+++ b/dotnet/README.MD
@@ -1,0 +1,4 @@
+## Development information
+
+You can build locally the extension by using ./dotnet/build-packages-local.sh
+It will both build the application and upload to a dev nuget feed that you can use on your app. This feed can be used by setting the variable `SCM_SITEEXTENSIONS_FEED_URL` to `https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v2` in your app.

--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -5,7 +5,7 @@ AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpac
 TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$TRACER_SHA/windows-tracer-home.zip"
 
 echo "Downloading tracer from $TRACER_DOWNLOAD_URL"
-#wget -O tracer.zip $TRACER_DOWNLOAD_URL
+wget -O tracer.zip $TRACER_DOWNLOAD_URL
 
 echo "Unzipping tracer"
 unzip tracer.zip -d dotnet/content/Tracer
@@ -17,7 +17,7 @@ echo "Clean previous runs"
 rm -r dotnet/content/v*
 
 echo "Downloading agent from ${AGENT_DOWNLOAD_URL}"
-#wget -O agent.zip $AGENT_DOWNLOAD_URL
+wget -O agent.zip $AGENT_DOWNLOAD_URL
 unzip agent.zip -d dotnet-agent-extract
 
 echo "Moving agent executables"

--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -1,21 +1,27 @@
-DEVELOPMENT_VERSION="0.2.114-prerelease"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.35.2-1-x86_64.zip"
-TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/INSTALL_SHA/windows-tracer-home.zip"
+DEVELOPMENT_VERSION="$1"
+TRACER_SHA="$2"
 
-echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"
-wget -O tracer.zip $TRACER_DOWNLOAD_URL
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.35.2-1-x86_64.zip"
+TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/$TRACER_SHA/windows-tracer-home.zip"
+
+echo "Downloading tracer from $TRACER_DOWNLOAD_URL"
+#wget -O tracer.zip $TRACER_DOWNLOAD_URL
+
 echo "Unzipping tracer"
 unzip tracer.zip -d dotnet/content/Tracer
 
 DEVELOPMENT_VERSION_FILE=$( echo ${DEVELOPMENT_VERSION} | tr '.' '_' )
 DEVELOPMENT_DIR=dotnet/content/v${DEVELOPMENT_VERSION_FILE}
 
+echo "Clean previous runs"
+rm -r dotnet/content/v*
+
 echo "Downloading agent from ${AGENT_DOWNLOAD_URL}"
-wget -O agent.zip $AGENT_DOWNLOAD_URL
+#wget -O agent.zip $AGENT_DOWNLOAD_URL
 unzip agent.zip -d dotnet-agent-extract
 
 echo "Moving agent executables"
-mv dotnet-agent-extract/bin/agent/dogstatsd.exe dotnet/content/Agent
+mv dotnet-agent-extract/bin/agent/dogstatsd.exe dotnet/content/Agent/dogstatsd.exe
 mv dotnet-agent-extract/bin/agent/trace-agent.exe dotnet/content/Agent/datadog-trace-agent.exe
 
 echo "Versioning development files"

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -16,7 +16,7 @@ unzip agent.zip -d dotnet-agent-extract
 
 echo "Moving agent executables"
 mkdir dotnet/content/Agent
-mv dotnet-agent-extract/bin/agent/dogstatsd.exe dotnet/content/Agent
+mv dotnet-agent-extract/bin/agent/dogstatsd.exe dotnet/content/Agent/dogstatsd.exe
 mv dotnet-agent-extract/bin/agent/trace-agent.exe dotnet/content/Agent/datadog-trace-agent.exe
 
 echo "Copying files for development version"

--- a/dotnet/deploy-packages-local.sh
+++ b/dotnet/deploy-packages-local.sh
@@ -1,0 +1,7 @@
+INSTALL_SHA="38787d2e9cadd408f541675e95fab7b9a687d559"
+PACKAGE_BUILD_VERSION="0.2.659679454"
+
+# Handle later the possibility to use a local commit
+./dotnet/build-packages-dev.sh $PACKAGE_BUILD_VERSION $INSTALL_SHA
+# SET AZDO_PAT in external env variable as it's a secret 
+./dotnet/upload-dev-nuget.sh $PACKAGE_BUILD_VERSION $AZDO_PAT 

--- a/dotnet/upload-dev-nuget.sh
+++ b/dotnet/upload-dev-nuget.sh
@@ -1,0 +1,5 @@
+dev_version="$1"
+AZDO_PAT=$2
+
+dotnet nuget add source https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json --name Public_Feed --username any_string --password $AZDO_PAT --store-password-in-clear-text
+dotnet nuget push package/DevelopmentVerification.DdDotNet.Apm.$dev_version.nupkg --source Public_Feed --api-key any_string


### PR DESCRIPTION
Allow deploying a nuget to the [dev package feed](https://dev.azure.com/datadoghq/dd-trace-dotnet/_artifacts/feed/Public_Feed/NuGet/DevelopmentVerification.DdDotNet.Apm/overview/0.2.710210174) with local AAS modification (xdt files, packaging...).
To do so, I tried to reuse what Alexander had setup for nightly deploys. So we now have `deploy-packages-local.sh` that will call the same scripts given a tracer sha and a package version. 
I've also added a bit of cleanup for this process to be ran several times (remove intermediary files, .gitignore). 

There are still a few things to improve.  The main ones being:
- Stop modifying files where they are committed, so that you don't have to revert modifications in between each run
- Use a local version of the tracer (even though copying the tracer files on an existing extension works well)

I've tested the changes, both locally, and on the deploy github action (cf [this run](https://github.com/DataDog/datadog-aas-extension/runs/7444869739?check_suite_focus=true) )