### PR TITLE
Use JAVA_TOOL_OPTIONS instead of JAVA_OPTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ obj/
 /dotnet/content/Agent/dogstatsd.exe
 /dotnet/content/Agent/datadog-trace-agent.exe
 /package/*
+.idea

--- a/java/content/applicationHost.xdt
+++ b/java/content/applicationHost.xdt
@@ -52,8 +52,8 @@
         <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
 		
 		<!-- Java Tracer Specific Variables -->
-        <add name="JAVA_OPTS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="JAVA_OPTS" value="-javaagent:%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Tracer\dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.logFile=%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN\dd-java-agent.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="JAVA_TOOL_OPTIONS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="JAVA_TOOL_OPTIONS" value="-javaagent:%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Tracer\dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.logFile=%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN\dd-java-agent.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
       </environmentVariables>
     </runtime>


### PR DESCRIPTION
`JAVA_TOOL_OPTIONS` should be used by tools while `JAVA_OPTS` should be used by users. This change fixes the extension clobbering `JAVA_OPTS` like max memory set by the user.