### PR TITLE
Fail the packaging if we fail to get the release artifacts

### DIFF
--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -4,6 +4,10 @@ TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-art
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"
 wget -O tracer.zip $TRACER_DOWNLOAD_URL
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
 echo "Unzipping tracer"
 unzip tracer.zip -d dotnet/content/Tracer
 
@@ -12,6 +16,10 @@ DEVELOPMENT_DIR=dotnet/content/v${DEVELOPMENT_VERSION_FILE}
 
 echo "Downloading agent from ${AGENT_DOWNLOAD_URL}"
 wget -O agent.zip $AGENT_DOWNLOAD_URL
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
 unzip agent.zip -d dotnet-agent-extract
 
 echo "Moving agent executables"

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -4,8 +4,15 @@ TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/downloa
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"
 wget -O tracer.zip $TRACER_DOWNLOAD_URL
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
 echo "Unzipping tracer"
 unzip tracer.zip -d dotnet/content/Tracer
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
 
 RELEASE_VERSION_FILE=$( echo ${RELEASE_VERSION} | tr '.' '_' )
 RELEASE_DIR=$CI_PROJECT_DIR/dotnet/content/v${RELEASE_VERSION_FILE}


### PR DESCRIPTION
During the last release, we've seen that the dev packaging hadn't been always working.
It happened to me again this morning. It happens if we fail to download the tracer zip file as currently the script doesn't fail

So I've added extra checks to make sure the script fails in that case