### PR TITLE
Add app with stats enabled in the automatic deployment

### DIFF
--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -83,15 +83,18 @@ jobs:
           inlineScript: |
             resourceGroupName="apm-aas-junkyard"
             aasName="dd-dotnet-latest-build"
+            aasStatsName="dd-dotnet-latest-build-stats"
 
             echo "Login"
             az login --service-principal -u ${{ secrets.AZURE_APP_ID }} -p ${{ secrets.AZURE_PASSWORD }} --tenant ${{ secrets.AZURE_TENANT }}
 
-            echo "Update Site Extension"
+            echo "Update Site Extensions"
             az resource create --resource-group $resourceGroupName --resource-type "Microsoft.Web/sites/siteextensions" --name "$aasName/siteextensions/DevelopmentVerification.DdDotNet.Apm" -p "{}"
+            az resource create --resource-group $resourceGroupName --resource-type "Microsoft.Web/sites/siteextensions" --name "$aasStatsName/siteextensions/DevelopmentVerification.DdDotNet.Apm" -p "{}"
 
             echo "Waiting 10 seconds for extension to be actually installed"
             sleep 10
 
             echo "Restart Application"
             az webapp restart --resource-group $resourceGroupName --name $aasName
+            az webapp restart --resource-group $resourceGroupName --name $aasStatsName


### PR DESCRIPTION
I've created a `dd-dotnet-latest-build-stats` application to do performance testing of the tracer with stats computation enabled.

This PR adds it in the deployment script that runs when we launch a code freeze.

I've tested it from the branch and it works. Cf [action run](https://github.com/DataDog/datadog-aas-extension/actions/runs/3345838747/jobs/5541875014).