### PR TITLE
Add common error handling to wrapper script.

### DIFF
--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -54,7 +54,7 @@ setUpDotnetEnv() {
     DD_DOTNET_TRACER_URL=https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DD_DOTNET_TRACER_VERSION}/${DD_DOTNET_TRACER_FILE}
 
     echo "Installing .NET tracer from $DD_DOTNET_TRACER_URL"
-    wget $DD_DOTNET_TRACER_URL || return
+    curl -L $DD_DOTNET_TRACER_URL -o $DD_DOTNET_TRACER_FILE|| return
     tar -xzf $DD_DOTNET_TRACER_FILE || return
 
     export CORECLR_ENABLE_PROFILING=1

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -5,18 +5,18 @@ CURRENT_DIR=$(pwd)
 setUpCommonEnv() {
     echo "Creating datadog directory"
     DD_DIR="/home/site/wwwroot/datadog"
-    mkdir -p $DD_DIR || return
+    mkdir -p $DD_DIR && cd $DD_DIR || return
 
     echo "Downloading required datadog binaries"
     DD_BINARIES="https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw"
-    curl -L ${DD_BINARIES}/datadog-${DD_RUNTIME}.tar.gz -o $DD_DIR/datadog.tar.gz || return
+    curl -L $DD_BINARIES/datadog.tar.gz -o datadog.tar.gz || return
 
     echo "Decompressing files"
-    tar -xzf $DD_DIR/datadog.tar.gz || return
-    rm $DD_DIR/datadog.tar.gz
+    tar -xzf datadog.tar.gz || return
+    rm datadog.tar.gz
 
     echo "Starting trace agent"
-    ./datadog/trace-agent &
+    ./trace-agent &
 }
 
 setUpNodeEnv() {
@@ -24,8 +24,10 @@ setUpNodeEnv() {
 
     setUpCommonEnv || return
 
+    npm install dd-trace || return
+
     # if any of the above fails, we must not update the NODE_OPTIONS
-    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js $NODE_OPTIONS"
+    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init $NODE_OPTIONS"
 }
 
 setUpDotnetEnv() {
@@ -49,4 +51,4 @@ fi
 
 echo "Executing start command: \"$DD_START_APP\""
 cd $CURRENT_DIR
-$DD_START_APP
+eval "$DD_START_APP"

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -3,10 +3,12 @@
 setUpNodeEnv() {
     echo "Setting up Datadog tracing for Node"
     DD_DIR="/home/site/wwwroot/datadog-js"
-    mkdir -p $DD_DIR
+    mkdir -p $DD_DIR || return
 
-    curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-js.tar.gz" -o $DD_DIR/datadog-js.tar.gz
-    tar -xzf $DD_DIR/datadog-js.tar.gz && rm $DD_DIR/datadog-js.tar.gz
+    curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-js.tar.gz" -o $DD_DIR/datadog-js.tar.gz || return
+
+    tar -xzf $DD_DIR/datadog-js.tar.gz || return
+    rm $DD_DIR/datadog-js.tar.gz
 
     export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js"
 }
@@ -14,11 +16,12 @@ setUpNodeEnv() {
 setUpDotnetEnv() {
     echo "Setting up Datadog tracing for .NET"
 
-    echo "Downloading "
-    curl -L "https://gist.github.com/jcstorms1/a712f0df568e81b055b2234b4ec71cd9/raw/datadog-dotnet.tar.gz" -o /home/datadog-dotnet.tar.gz
+    echo "Downloading"
+    curl -L "https://gist.github.com/jcstorms1/a712f0df568e81b055b2234b4ec71cd9/raw/datadog-dotnet.tar.gz" -o /home/datadog-dotnet.tar.gz || return
 
     cd /home/
-    tar -xzf datadog-dotnet.tar.gz && rm datadog-dotnet.tar.gz
+    tar -xzf datadog-dotnet.tar.gz || return
+    rm datadog-dotnet.tar.gz
 
     echo "Starting application"
     export CORECLR_ENABLE_PROFILING=1

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -1,35 +1,39 @@
 #!/usr/bin/env sh
 
-setUpNodeEnv() {
-    echo "Setting up Datadog tracing for Node"
-    DD_DIR="/home/site/wwwroot/datadog-js"
+setUpCommonEnv() {
+    echo "Creating datadog directory"
     mkdir -p $DD_DIR || return
 
-    curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-js.tar.gz" -o $DD_DIR/datadog-js.tar.gz || return
+    echo "Downloading required datadog modules"
+    curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-${DD_RUNTIME}.tar.gz" -o $DD_DIR/datadog.tar.gz || return
 
-    tar -xzf $DD_DIR/datadog-js.tar.gz || return
-    rm $DD_DIR/datadog-js.tar.gz
+    echo "Decompressing files"
+    tar -xzf $DD_DIR/datadog.tar.gz || return
+    rm $DD_DIR/datadog.tar.gz
 
+    echo "Starting trace agent"
+    ./datadog/trace-agent &
+}
+
+setUpNodeEnv() {
+    echo "Setting up Datadog tracing for Node"
+    DD_DIR="/home/site/wwwroot/datadog"
+
+    setUpCommonEnv || return
+
+    # if any of the above fails, we must not update the NODE_OPTIONS
     export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js"
 }
 
 setUpDotnetEnv() {
     echo "Setting up Datadog tracing for .NET"
 
-    echo "Downloading"
-    curl -L "https://gist.github.com/jcstorms1/a712f0df568e81b055b2234b4ec71cd9/raw/datadog-dotnet.tar.gz" -o /home/datadog-dotnet.tar.gz || return
+    setUpCommonEnv || return
 
-    cd /home/
-    tar -xzf datadog-dotnet.tar.gz || return
-    rm datadog-dotnet.tar.gz
-
-    echo "Starting application"
     export CORECLR_ENABLE_PROFILING=1
     export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     export CORECLR_PROFILER_PATH=/home/datadog-dotnet/datadog/Datadog.Trace.ClrProfiler.Native.so
     export DD_DOTNET_TRACER_HOME=/home/datadog-dotnet/datadog
-
-    ./datadog-dotnet/trace-agent &
 
     cd /home/site/wwwroot
 }
@@ -42,4 +46,5 @@ elif [ "$DD_RUNTIME" = "dotnet" ]; then
     setUpDotnetEnv;
 fi
 
+echo "Executing start command: \"$DD_START_APP\""
 $DD_START_APP

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -7,7 +7,7 @@ setUpCommonEnv() {
     DD_DIR="/home/site/wwwroot/datadog"
     mkdir -p $DD_DIR || return
 
-    echo "Downloading required datadog modules"
+    echo "Downloading required datadog binaries"
     DD_BINARIES="https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw"
     curl -L ${DD_BINARIES}/datadog-${DD_RUNTIME}.tar.gz -o $DD_DIR/datadog.tar.gz || return
 

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -14,7 +14,7 @@ setUpCommonEnv() {
     echo "Creating datadog directory"
     mkdir -p $DD_DIR && cd $DD_DIR || return
 
-    echo "Downloading required datadog binaries"
+    echo "Downloading required datadog binaries from $DD_BINARIES_URL"
     curl -L $DD_BINARIES_URL/datadog.tar.gz -o datadog.tar.gz || return
 
     echo "Decompressing files"

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -5,7 +5,8 @@ setUpCommonEnv() {
     mkdir -p $DD_DIR || return
 
     echo "Downloading required datadog modules"
-    curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-${DD_RUNTIME}.tar.gz" -o $DD_DIR/datadog.tar.gz || return
+    DD_BINARIES="https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw"
+    curl -L ${DD_BINARIES}/datadog-${DD_RUNTIME}.tar.gz -o $DD_DIR/datadog.tar.gz || return
 
     echo "Decompressing files"
     tar -xzf $DD_DIR/datadog.tar.gz || return

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -32,16 +32,14 @@ setUpDotnetEnv() {
     ./datadog-dotnet/trace-agent &
 
     cd /home/site/wwwroot
-    $DD_START_APP
 }
 
 if [ -z "$DD_RUNTIME" ]; then
     echo "Runtime is not set. Skipping Datadog startup"
-    $DD_START_APP
-    exit
 elif [ "$DD_RUNTIME" = "node" ]; then
     setUpNodeEnv;
-    $DD_START_APP
 elif [ "$DD_RUNTIME" = "dotnet" ]; then
     setUpDotnetEnv;
 fi
+
+$DD_START_APP

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -23,7 +23,7 @@ setUpNodeEnv() {
     setUpCommonEnv || return
 
     # if any of the above fails, we must not update the NODE_OPTIONS
-    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js"
+    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js $NODE_OPTIONS"
 }
 
 setUpDotnetEnv() {

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -32,6 +32,7 @@ setUpNodeEnv() {
 
     setUpCommonEnv || return
 
+    echo "Installing Node tracer"
     npm install --prefix $DD_DIR dd-trace || return
 
     ORIG_NODE_OPTIONS=$NODE_OPTIONS
@@ -46,10 +47,20 @@ setUpDotnetEnv() {
 
     setUpCommonEnv || return
 
+    if [ -z "$DD_DOTNET_TRACER_VERSION" ]; then
+        DD_DOTNET_TRACER_VERSION=2.19.0
+    fi
+    DD_DOTNET_TRACER_FILE=datadog-dotnet-apm-${DD_DOTNET_TRACER_VERSION}.tar.gz
+    DD_DOTNET_TRACER_URL=https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DD_DOTNET_TRACER_VERSION}/${DD_DOTNET_TRACER_FILE}
+
+    echo "Installing .NET tracer from $DD_DOTNET_TRACER_URL"
+    wget $DD_DOTNET_TRACER_URL || return
+    tar -xzf $DD_DOTNET_TRACER_FILE || return
+
     export CORECLR_ENABLE_PROFILING=1
     export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-    export CORECLR_PROFILER_PATH=/home/datadog-dotnet/datadog/Datadog.Trace.ClrProfiler.Native.so
-    export DD_DOTNET_TRACER_HOME=/home/datadog-dotnet/datadog
+    export CORECLR_PROFILER_PATH=${DD_DIR}/Datadog.Trace.ClrProfiler.Native.so
+    export DD_DOTNET_TRACER_HOME=${DD_DIR}
 }
 
 if [ -z "$DD_RUNTIME" ]; then

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -17,6 +17,8 @@ setUpCommonEnv() {
 
     echo "Starting trace agent"
     ./trace-agent &
+    TRACER_PID=$!
+    trap 'kill $TRACER_PID ; exit' INT
 }
 
 setUpNodeEnv() {

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh 
+#!/usr/bin/env sh
 
 setUpNodeEnv() {
     echo "Setting up Datadog tracing for Node"
@@ -7,7 +7,7 @@ setUpNodeEnv() {
 
     curl -L "https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw/datadog-js.tar.gz" -o $DD_DIR/datadog-js.tar.gz
     tar -xzf $DD_DIR/datadog-js.tar.gz && rm $DD_DIR/datadog-js.tar.gz
-    
+
     export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init --require=$DD_DIR/start-trace-agent.js"
 }
 
@@ -16,7 +16,7 @@ setUpDotnetEnv() {
 
     echo "Downloading "
     curl -L "https://gist.github.com/jcstorms1/a712f0df568e81b055b2234b4ec71cd9/raw/datadog-dotnet.tar.gz" -o /home/datadog-dotnet.tar.gz
-    
+
     cd /home/
     tar -xzf datadog-dotnet.tar.gz && rm datadog-dotnet.tar.gz
 
@@ -27,7 +27,7 @@ setUpDotnetEnv() {
     export DD_DOTNET_TRACER_HOME=/home/datadog-dotnet/datadog
 
     ./datadog-dotnet/trace-agent &
-    
+
     cd /home/site/wwwroot
     $DD_START_APP
 }

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 
+CURRENT_DIR=$(pwd)
+
 setUpCommonEnv() {
     echo "Creating datadog directory"
+    DD_DIR="/home/site/wwwroot/datadog"
     mkdir -p $DD_DIR || return
 
     echo "Downloading required datadog modules"
@@ -18,7 +21,6 @@ setUpCommonEnv() {
 
 setUpNodeEnv() {
     echo "Setting up Datadog tracing for Node"
-    DD_DIR="/home/site/wwwroot/datadog"
 
     setUpCommonEnv || return
 
@@ -35,8 +37,6 @@ setUpDotnetEnv() {
     export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     export CORECLR_PROFILER_PATH=/home/datadog-dotnet/datadog/Datadog.Trace.ClrProfiler.Native.so
     export DD_DOTNET_TRACER_HOME=/home/datadog-dotnet/datadog
-
-    cd /home/site/wwwroot
 }
 
 if [ -z "$DD_RUNTIME" ]; then
@@ -48,4 +48,5 @@ elif [ "$DD_RUNTIME" = "dotnet" ]; then
 fi
 
 echo "Executing start command: \"$DD_START_APP\""
+cd $CURRENT_DIR
 $DD_START_APP

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -32,10 +32,13 @@ setUpNodeEnv() {
 
     setUpCommonEnv || return
 
-    npm install dd-trace || return
+    npm install --prefix $DD_DIR dd-trace || return
 
-    # if any of the above fails, we must not update the NODE_OPTIONS
-    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init $NODE_OPTIONS"
+    ORIG_NODE_OPTIONS=$NODE_OPTIONS
+    export NODE_OPTIONS="--require=$DD_DIR/node_modules/dd-trace/init $ORIG_NODE_OPTIONS"
+
+    # confirm updates to NODE_OPTIONS
+    node --help >/dev/null || (export NODE_OPTIONS=$ORIG_NODE_OPTIONS && return)
 }
 
 setUpDotnetEnv() {

--- a/node/linux/datadog-aas-node-linux/datadog_wrapper
+++ b/node/linux/datadog-aas-node-linux/datadog_wrapper
@@ -2,14 +2,20 @@
 
 CURRENT_DIR=$(pwd)
 
+if [ -z "$DD_DIR" ]; then
+    DD_DIR="/home/datadog"
+fi
+
+if [ -z "$DD_BINARIES_URL" ]; then
+    DD_BINARIES_URL="https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw"
+fi
+
 setUpCommonEnv() {
     echo "Creating datadog directory"
-    DD_DIR="/home/site/wwwroot/datadog"
     mkdir -p $DD_DIR && cd $DD_DIR || return
 
     echo "Downloading required datadog binaries"
-    DD_BINARIES="https://gist.github.com/jcstorms1/7e73ab0da121f42d1843dac5b75c21cb/raw"
-    curl -L $DD_BINARIES/datadog.tar.gz -o datadog.tar.gz || return
+    curl -L $DD_BINARIES_URL/datadog.tar.gz -o datadog.tar.gz || return
 
     echo "Decompressing files"
     tar -xzf datadog.tar.gz || return


### PR DESCRIPTION
This pull request adds error handling to the wrapper script along with DRY'ing up the code.

Work that still needs to be done:
+ Which is better `npm install ddtrace` or downloading a tarfile we make ourselves?
+ Which linux version of the dotnet tracer do we need to use?

I will add code comments to help explain some of my thinking.