### PR TITLE
[Serverless] Update runtime detection in Linux wrapper script

### DIFF
--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -2,6 +2,9 @@
 
 CURRENT_DIR=$(pwd)
 
+# Required to add the AAS metadata 
+export DD_AZURE_APP_SERVICES=1
+
 if [ -z "$DD_DIR" ]; then
     DD_DIR="/home/datadog"
 fi

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -63,11 +63,9 @@ setUpDotnetEnv() {
     export DD_DOTNET_TRACER_HOME=${DD_DIR}
 }
 
-if [ -z "$DD_RUNTIME" ]; then
-    echo "Runtime is not set. Skipping Datadog startup"
-elif [ "$DD_RUNTIME" = "node" ]; then
+if [ "$WEBSITE_STACK" = "NODE" ]; then
     setUpNodeEnv;
-elif [ "$DD_RUNTIME" = "dotnet" ]; then
+elif [ "$WEBSITE_STACK" = "DOTNETCORE" ]; then
     setUpDotnetEnv;
 fi
 


### PR DESCRIPTION
This just updates the wrapper script to grab the runtime from the AAS environment and automatically sets DD_AZURE_APP_SERVICES 