### PR TITLE
[Serverless]  Add logic to catch curl failures in the Linux script

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -11,4 +11,4 @@ _Note: Currently only NODE is supported._
 - ### General Settings
     - Add the following to the startup command box
     
-          curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-extension/linux-v0.1.2-beta/linux/datadog_wrapper | bash
+          curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-extension/linux-v0.1.3-beta/linux/datadog_wrapper | bash

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -31,11 +31,12 @@ setUpCommonEnv() {
         fi
 
         echo "Downloading required Datadog binaries from $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE"
-        if curl -L --fail $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE; then
+        if curl -L --fail $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE; then echo
             echo "Decompressing files"
             tar -zxf $FILE || return
         else 
             echo "Failed to download the Datadog binary succesfully."
+            return
         fi
         
     else

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -14,7 +14,7 @@ if [ -z "$DD_BINARIES_URL" ]; then
 fi
 
 if [ -z "$DD_AAS_LINUX_VERSION" ]; then
-    DD_AAS_LINUX_VERSION="linux-v0.1.2-beta"
+    DD_AAS_LINUX_VERSION="linux-v0.1.3-beta"
 fi
 
 setUpCommonEnv() {
@@ -31,10 +31,13 @@ setUpCommonEnv() {
         fi
 
         echo "Downloading required datadog binaries from $DD_BINARIES_URL"
-        curl -L $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE || return
-
-        echo "Decompressing files"
-        tar -zxf $FILE || return
+        if curl -L --fail $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE; then
+            echo "Decompressing files"
+            tar -zxf $FILE || return
+        else 
+            echo "Failed to download the datadog binary succesfully."
+        fi
+        
     else
         echo "Version $DD_AAS_LINUX_VERSION of the trace agent previously installed"
     fi

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -30,7 +30,7 @@ setUpCommonEnv() {
             rm trace-agent* 
         fi
 
-        echo "Downloading required Datadog binaries from $DD_BINARIES_URL"
+        echo "Downloading required Datadog binaries from $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE"
         if curl -L --fail $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE; then
             echo "Decompressing files"
             tar -zxf $FILE || return

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -18,7 +18,7 @@ if [ -z "$DD_AAS_LINUX_VERSION" ]; then
 fi
 
 setUpCommonEnv() {
-    echo "Creating datadog directory"
+    echo "Creating Datadog directory"
     mkdir -p $DD_DIR && cd $DD_DIR || return
 
     FILE=trace-agent-${DD_AAS_LINUX_VERSION}.tar.gz
@@ -30,12 +30,12 @@ setUpCommonEnv() {
             rm trace-agent* 
         fi
 
-        echo "Downloading required datadog binaries from $DD_BINARIES_URL"
+        echo "Downloading required Datadog binaries from $DD_BINARIES_URL"
         if curl -L --fail $DD_BINARIES_URL/$DD_AAS_LINUX_VERSION/$FILE -o $FILE; then
             echo "Decompressing files"
             tar -zxf $FILE || return
         else 
-            echo "Failed to download the datadog binary succesfully."
+            echo "Failed to download the Datadog binary succesfully."
         fi
         
     else


### PR DESCRIPTION
Previously a failed curl command would block a proper install on restart. This catches that failure so the script can run correctly on the next attempt.