### PR TITLE
Add app for the .NET profiler only in the automatic deployment

### DIFF
--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -84,6 +84,7 @@ jobs:
             resourceGroupName="apm-aas-junkyard"
             aasName="dd-dotnet-latest-build"
             aasStatsName="dd-dotnet-latest-build-stats"
+            aasProfilerOnlyName="dd-dotnet-latest-build-profiler-only"
 
             echo "Login"
             az login --service-principal -u ${{ secrets.AZURE_APP_ID }} -p ${{ secrets.AZURE_PASSWORD }} --tenant ${{ secrets.AZURE_TENANT }}
@@ -91,6 +92,7 @@ jobs:
             echo "Update Site Extensions"
             az resource create --resource-group $resourceGroupName --resource-type "Microsoft.Web/sites/siteextensions" --name "$aasName/siteextensions/DevelopmentVerification.DdDotNet.Apm" -p "{}"
             az resource create --resource-group $resourceGroupName --resource-type "Microsoft.Web/sites/siteextensions" --name "$aasStatsName/siteextensions/DevelopmentVerification.DdDotNet.Apm" -p "{}"
+            az resource create --resource-group $resourceGroupName --resource-type "Microsoft.Web/sites/siteextensions" --name "$aasProfilerOnlyName/siteextensions/DevelopmentVerification.DdDotNet.Apm" -p "{}"
 
             echo "Waiting 10 seconds for extension to be actually installed"
             sleep 10
@@ -98,3 +100,4 @@ jobs:
             echo "Restart Application"
             az webapp restart --resource-group $resourceGroupName --name $aasName
             az webapp restart --resource-group $resourceGroupName --name $aasStatsName
+            az webapp restart --resource-group $resourceGroupName --name $aasProfilerOnlyName


### PR DESCRIPTION
I've created a `dd-dotnet-latest-build-profiler-only` application to do performance testing of the profiler only.

This PR adds it in the deployment script that runs when we launch a code freeze.

Tested the branch https://github.com/DataDog/datadog-aas-extension/actions/runs/3970137402 .