### PR TITLE
[.NET] Remove duplicate variable from applicationHost.xdt

### DIFF
--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -40,7 +40,6 @@
         <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 		
         <add name="DD_AGENT_HOST" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
@@ -82,7 +81,6 @@
         <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
         <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
         <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
-        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd package server variable -->
 		
         <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->


### PR DESCRIPTION
In #188 I accidentally introduced a duplicate variable into the applicationHost.xdt. This caused the app to not startup correctly