### PR TITLE
[.NET Profiler] Setup env var(s) for profiler

### DIFF
--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -133,10 +133,18 @@ setUpDotnetEnv() {
         return
     fi
 
+    echo "Exporting environment variables"
     export CORECLR_ENABLE_PROFILING=1
     export CORECLR_PROFILER="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
     export CORECLR_PROFILER_PATH="${DD_DIR}/Datadog.Trace.ClrProfiler.Native.so"
     export DD_DOTNET_TRACER_HOME="${DD_DIR}"
+
+    if [[ "${DD_PROFILING_ENABLED:-,,}" == "1" ]]; then
+        echo "Profiler is enabled."
+        export LD_PRELOAD="${DD_DIR}/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"
+    fi
+    echo "Creating log folder for .NET APM"
+    ${DD_DIR}/createLogPath.sh
 }
 
 setUpJavaEnv() {

--- a/linux/datadog_wrapper
+++ b/linux/datadog_wrapper
@@ -203,6 +203,10 @@ setUpPyEnv() {
 }
 
 main
+
+# Allow the profiler to add this to its tag
+export WEBSITE_OS="linux"
+
 echo "Executing start command: \"$DD_START_APP\""
 cd "$CURRENT_DIR"
 eval "$DD_START_APP"


### PR DESCRIPTION
To enable the profiler, we need to set the `LD_PRELOAD` env var. We will set the env var for the customers to avoid painful configuration on their end.
Create log folders so we can retrieve them in case of customer case