### PR TITLE
Bump the Java extension version to 1.1.0

### DIFF
--- a/java/build-packages.sh
+++ b/java/build-packages.sh
@@ -1,6 +1,6 @@
 
-RELEASE_VERSION="1.0.0"
-DEVELOPMENT_VERSION="1.0.0-prerelease"
+RELEASE_VERSION="1.1.0"
+DEVELOPMENT_VERSION="1.1.0-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.49.0-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-java/releases/download/v1.30.1/dd-java-agent-1.30.1.jar"
 


### PR DESCRIPTION
Apparently, there is already 1.0.0 package @ AAS with dd-trace-java 1.20.1

Let's try bumping the version to 1.1.0