### PR TITLE
Fix Java nuspec naming

### DIFF
--- a/java/Datadog.AzureAppServices.Java.Apm.csproj
+++ b/java/Datadog.AzureAppServices.Java.Apm.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NuspecProperties>version=$(Version)</NuspecProperties>
-    <NuspecFile>Datadog.AzureAppServices.Java.nuspec</NuspecFile>
+    <NuspecFile>Datadog.AzureAppServices.Java.Apm.nuspec</NuspecFile>
   </PropertyGroup>
 </Project>

--- a/java/Datadog.AzureAppServices.Java.Apm.nuspec
+++ b/java/Datadog.AzureAppServices.Java.Apm.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>Datadog.AzureAppServices.Java</id>
+    <id>Datadog.AzureAppServices.Java.Apm</id>
     <title>Java Datadog APM</title>
     <authors>Datadog</authors>
     <version>0.0.0</version> <!-- placeholder that is overridden -->
@@ -15,7 +15,7 @@
     <tags>AzureSiteExtension Datadog Java APM Tracing Tracer Monitoring</tags>
     <packageTypes>
       <packageType name="AzureSiteExtension" />
-    </packageTypes>  
+    </packageTypes>
   </metadata>
   <files>
     <file src="content\**\*.*" target="content" />

--- a/java/build-packages.sh
+++ b/java/build-packages.sh
@@ -42,7 +42,7 @@ mv -v java/content/Agent $RELEASE_DIR/Agent
 
 echo "Creating release nuget package"
 echo "Packing nuspec file via arcane roundabout csproj process"
-dotnet pack java/Datadog.AzureAppServices.Java.csproj -p:Version=${RELEASE_VERSION} -p:NoBuild=true -p:NoDefaultExcludes=true -o package
+dotnet pack java/Datadog.AzureAppServices.Java.Apm.csproj -p:Version=${RELEASE_VERSION} -p:NoBuild=true -p:NoDefaultExcludes=true -o package
 
 echo "Versioning development files"
 sed -i "s/vFOLDERUNKNOWN/v${DEVELOPMENT_VERSION_FILE}/g" dev-java/content/Agent/datadog.yaml

--- a/java/content/install.cmd
+++ b/java/content/install.cmd
@@ -5,7 +5,7 @@ REM Entrypoint: https://github.com/projectkudu/kudu/blob/13824205c60a4bdb53896b9
 
 set version=vUNKNOWN
 set log_prefix=%date% %time% ^[%version%^]
-set log_file=..\..\Datadog.AzureAppServices.Java-Install.txt
+set log_file=..\..\Datadog.AzureAppServices.Java.Apm-Install.txt
 
 echo %log_prefix% Starting install. >> %log_file%
 


### PR DESCRIPTION
There was an issue with the naming convention of our nuget package that resulted in installations failing in AAS. Renaming the nupkg resolves the issue.