### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -25,10 +25,10 @@ jobs:
           TRACER_VERSION="$(grep -o -e dd-trace-dotnet/releases/download/v[0-9]*\.[0-9]*\.[0-9]* dotnet/build-packages.sh | sed 's#dd-trace-dotnet/releases/download/v##')"
           TAGNAME=dotnet-v$VERSION
           AGENT_VERSION="$(grep -o -e agent-binaries-[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/agent-binaries-//')"
-          echo "::set-output name=tagname::$TAGNAME"
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=tracer_version::$TRACER_VERSION"
-          echo "::set-output name=agent_version::$AGENT_VERSION"
+          echo "tagname=$TAGNAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tracer_version=$TRACER_VERSION" >> "$GITHUB_OUTPUT"
+          echo "agent_version=$AGENT_VERSION" >> "$GITHUB_OUTPUT"
           git tag "$TAGNAME"
           git push origin "$TAGNAME"
       - name: Create Release

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -29,15 +29,15 @@ jobs:
         id: "set_variables"
         run: |
           if [[ ! -z "${{ github.event.inputs.version }}" ]]; then
-            echo "::set-output name=version::${{ github.event.inputs.version }}"
-            echo "::set-output name=tracer_version::${{ github.event.inputs.tracer_version }}"
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tracer_version=${{ github.event.inputs.tracer_version }}" >> "$GITHUB_OUTPUT"
           elif [[ ! -z "${{ github.event.client_payload.version }}" ]]; then
             TRACERVERSION=${{ github.event.client_payload.version }}
             echo "Version received from dd-trace-dotnet: $TRACERVERSION"
             TRACERVERSION=${TRACERVERSION:1}
             echo "Version received once normalized: $TRACERVERSION"
-            echo "::set-output name=version::${TRACERVERSION}00"
-            echo "::set-output name=tracer_version::$TRACERVERSION"
+            echo "version=${TRACERVERSION}00" >> "$GITHUB_OUTPUT"
+            echo "tracer_version=$TRACERVERSION" >> "$GITHUB_OUTPUT"
           else
             echo "Error. Versions weren't provided in input."
             exit 1
@@ -125,9 +125,9 @@ jobs:
           fi
 
           PR_BODY="$PR_BODY."
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=tracer_version::$TRACER_VERSION"
-          echo "::set-output name=pr_body::$PR_BODY"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tracer_version=$TRACER_VERSION" >> "$GITHUB_OUTPUT"
+          echo "pr_body=$PR_BODY" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: pr

--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -20,9 +20,9 @@ jobs:
         id: "set_variables"
         run: |
           if [[ ! -z "${{ github.event.inputs.sha }}" ]]; then
-            echo "::set-output name=sha::${{ github.event.inputs.sha }}"
+            echo "sha=${{ github.event.inputs.sha }}" >> "$GITHUB_OUTPUT"
           elif [[ ! -z "${{ github.event.client_payload.sha }}" ]]; then
-            echo "::set-output name=sha::${{ github.event.client_payload.sha }}"
+            echo "sha=${{ github.event.client_payload.sha }}" >> "$GITHUB_OUTPUT"
           else
             echo "Error. Hash commit wasn't provided in input."
             exit 1
@@ -52,7 +52,7 @@ jobs:
 
           DEV_VERSION=$major.$minor.$(echo $build | bc)
           echo New dev version is $DEV_VERSION
-          echo "::set-output name=dev_version::$DEV_VERSION"
+          echo "dev_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
 
           sed -i -e "s/DEVELOPMENT_VERSION=\"$CURRENT_DEV_VERSION/DEVELOPMENT_VERSION=\"$DEV_VERSION/g" dotnet/build-packages-dev.sh
           echo Replaced dev version in file.


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter