### PR TITLE
Fix .NET deploys to AAS

### DIFF
--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -43,8 +43,11 @@ jobs:
 
           major=0
           minor=0
-          build=${{ github.run_id }}
-          build="${build:1}"
+
+          # Use the current unit time (in seconds) as the build ID, to ensure monotonically increasing numbers
+          # Previously we were using github.run_id but this value is too large. This should work until
+          # date +%s returns > 2147483647, i.e. we're ok until Tuesday, 19 January 2038 03:14:08
+          build=$(date +%s)
 
           if [[ $CURRENT_DEV_VERSION =~ $splitVersionRegex ]]; then
             major="${BASH_REMATCH[1]}"

--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -1,4 +1,4 @@
-DEVELOPMENT_VERSION="0.2.117-prerelease"
+DEVELOPMENT_VERSION="0.3.0-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.51.0-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/INSTALL_SHA/windows-tracer-home.zip"
 


### PR DESCRIPTION
The AAS apps haven't been updating correctly, as the dev package versions were not monotonically increasing. 

Finally narrowed this down to be how we're generating the buildId - take the workflowID `8277249206` and drop the most significant value. Which clearly has been causing issues when it rolls over 🙄 

The reason for this approach is that the workflow ID is too large to fit in an `int`. So taken a different approach, using the current epoch time (in seconds) instead. That will do us for 10 years, and there's a simple fix subsequently (bump the minor and decrement by `int.MaxValue`)