### PR TITLE
[Node] Fix Typos in Production Nuget Package Name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,7 +223,7 @@ push-nuget-package-node-prod:
     - apt-get update
     - apt-get install -y awscli
     - export NUGET_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.nuget-api-key --with-decryption --query "Parameter.Value" --out text)
-    - dotnet nuget push package/Datadog.AzureAppServices.Node.${RELEASE_VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
+    - dotnet nuget push package/Datadog.AzureAppServices.Node.Apm.${RELEASE_VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
 
 update-self-monitoring-node-prod:
   tags: ["arch:amd64"]
@@ -242,7 +242,7 @@ update-self-monitoring-node-prod:
     - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring"
     - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring"
     - sleep 30
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows32-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.APM" --properties "{}" --debug
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows64-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.APM" --properties "{}" --debug
+    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows32-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.Apm" --properties "{}" --debug
+    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows64-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.Apm" --properties "{}" --debug
     - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring"
     - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring"

--- a/node/Datadog.AzureAppServices.Node.Apm.csproj
+++ b/node/Datadog.AzureAppServices.Node.Apm.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NuspecProperties>version=$(Version)</NuspecProperties>
-    <NuspecFile>Datadog.AzureAppServices.Node.nuspec</NuspecFile>
+    <NuspecFile>Datadog.AzureAppServices.Node.Apm.nuspec</NuspecFile>
   </PropertyGroup>
 </Project>

--- a/node/Datadog.AzureAppServices.Node.Apm.nuspec
+++ b/node/Datadog.AzureAppServices.Node.Apm.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>Datadog.AzureAppServices.Node</id>
+    <id>Datadog.AzureAppServices.Node.Apm</id>
     <title>Node Datadog APM</title>
     <authors>Datadog</authors>
     <version>0.0.0</version> <!-- placeholder that is overridden -->

--- a/node/scripts/build-packages.sh
+++ b/node/scripts/build-packages.sh
@@ -73,5 +73,5 @@ cp node/process_manager/target/x86_64-pc-windows-gnu/release/process_manager.exe
 cp node/process_manager/target/x86_64-pc-windows-gnu/release/process_manager.exe $DEVELOPMENT_DIR
 
 echo "Building nuget packages"
-dotnet pack node/Datadog.AzureAppServices.Node.csproj -p:Version=${RELEASE_VERSION} -p:NoBuild=true -p:NoDefaultExcludes=true -o package
+dotnet pack node/Datadog.AzureAppServices.Node.Apm.csproj -p:Version=${RELEASE_VERSION} -p:NoBuild=true -p:NoDefaultExcludes=true -o package
 dotnet pack node/DevelopmentVerification.DdNode.Apm.csproj -p:Version=${DEVELOPMENT_VERSION} -p:NoBuild=true -p:NoDefaultExcludes=true -o package


### PR DESCRIPTION
### What does this PR do?

Update production nuget package name from `Datadog.AzureAppServices.Node` to `Datadog.AzureAppServices.Node.Apm`.

### Motivation

Nuget package name should be the same as what's used in the beta so the same package is updated instead of creating a new package.

https://www.nuget.org/packages/Datadog.AzureAppServices.Node.Apm

### Additional Notes

### Describe how to test/QA your changes

Will verify upon release
