### PR TITLE
Github Workflow to Create PR for Bumping Node Extension Versions

### DIFF
--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -1,0 +1,66 @@
+name: Update Versions for Node Extension
+
+on:
+  schedule:
+    - cron: '0 14 * * *' # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Modify build-packages
+        id: version
+        run: |
+          CURRENT_AGENT_VERSION=$(awk '/AGENT_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
+          AGENT_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/datadog-agent/releases")
+          AGENT_VERSION=$(echo "$AGENT_RESPONSE" | jq -r --arg pattern "7\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+
+          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ]; then
+            echo "Updating agent to version: $AGENT_VERSION"
+            sed -i -e "s/AGENT_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/AGENT_VERSION=\"$AGENT_VERSION\"/" node/scripts/build-packages.sh
+            PR_BODY="Bumps the agent version for the Node Extension to $AGENT_VERSION."
+            PR_TITLE="[Node Version Bump] Bump agent to $AGENT_VERSION"
+            BRANCH_SUFFIX="agent-$AGENT_VERSION"
+          fi
+
+          CURRENT_TRACER_VERSION=$(awk '/TRACER_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
+          TRACER_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/dd-trace-js/releases")
+          TRACER_VERSION=$(echo "$TRACER_RESPONSE" | jq -r --arg pattern "v4\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name | ltrimstr("v")' | sort -V | tail -n 1)
+
+          if [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
+            echo "Updating tracer to version: $TRACER_VERSION"
+            sed -i -e "s/TRACER_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/TRACER_VERSION=\"$TRACER_VERSION\"/" node/scripts/build-packages.sh
+            PR_BODY="Bumps the tracer version for the Node Extension to $TRACER_VERSION."
+            PR_TITLE="[Node Version Bump] Bump tracer to $TRACER_VERSION"
+            BRANCH_SUFFIX="tracer-$TRACER_VERSION"
+          fi
+
+          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ] && [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
+            PR_BODY="Bumps the agent version for the Node Extension to $AGENT_VERSION and the tracer version to $TRACER_VERSION."
+            PR_TITLE="[Node Version Bump] Bump agent to $AGENT_VERSION and tracer to $TRACER_VERSION"
+            BRANCH_SUFFIX="agent-$AGENT_VERSION-tracer-$TRACER_VERSION"
+          fi
+
+          echo "pr_body=$PR_BODY" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+          echo "branch_suffix=$BRANCH_SUFFIX" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "node-extension-version-bump-${{steps.version.outputs.branch_suffix}}"
+          commit-message: "${{steps.version.outputs.pr_title}}"
+          delete-branch: true
+          title:  "${{steps.version.outputs.pr_title}}"
+          body: "${{steps.version.outputs.pr_body}}"
+
+      - name: Display output
+        run: |
+          echo "Pull Request Number - ${{ steps.pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}"

--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -2,7 +2,7 @@ name: Update Versions for Node Extension
 
 on:
   schedule:
-    - cron: '0 14 * * *' # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
+    - cron: "0 14 * * *" # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
 
 jobs:
   bump_version:
@@ -22,9 +22,8 @@ jobs:
           if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ]; then
             echo "Updating agent to version: $AGENT_VERSION"
             sed -i -e "s/AGENT_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/AGENT_VERSION=\"$AGENT_VERSION\"/" node/scripts/build-packages.sh
-            PR_BODY="Bumps the agent version for the Node Extension to $AGENT_VERSION."
-            PR_TITLE="[Node Version Bump] Bump agent to $AGENT_VERSION"
-            BRANCH_SUFFIX="agent-$AGENT_VERSION"
+            PR_BODY="Bumps the agent version to $AGENT_VERSION for the Node Extension."
+            PR_TITLE="[Node Extension] Bump agent to $AGENT_VERSION"
           fi
 
           CURRENT_TRACER_VERSION=$(awk '/TRACER_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
@@ -34,30 +33,27 @@ jobs:
           if [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
             echo "Updating tracer to version: $TRACER_VERSION"
             sed -i -e "s/TRACER_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/TRACER_VERSION=\"$TRACER_VERSION\"/" node/scripts/build-packages.sh
-            PR_BODY="Bumps the tracer version for the Node Extension to $TRACER_VERSION."
-            PR_TITLE="[Node Version Bump] Bump tracer to $TRACER_VERSION"
-            BRANCH_SUFFIX="tracer-$TRACER_VERSION"
+            PR_BODY="Bumps the tracer version to $TRACER_VERSION for the Node Extension."
+            PR_TITLE="[Node Extension] Bump tracer to $TRACER_VERSION"
           fi
 
           if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ] && [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
-            PR_BODY="Bumps the agent version for the Node Extension to $AGENT_VERSION and the tracer version to $TRACER_VERSION."
-            PR_TITLE="[Node Version Bump] Bump agent to $AGENT_VERSION and tracer to $TRACER_VERSION"
-            BRANCH_SUFFIX="agent-$AGENT_VERSION-tracer-$TRACER_VERSION"
+            PR_BODY="Bumps the agent version to $AGENT_VERSION and the tracer version to $TRACER_VERSION for the Node Extension."
+            PR_TITLE="[Node Extension] Bump agent to $AGENT_VERSION and tracer to $TRACER_VERSION"
           fi
 
           echo "pr_body=$PR_BODY" >> "$GITHUB_OUTPUT"
           echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
-          echo "branch_suffix=$BRANCH_SUFFIX" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "node-extension-version-bump-${{steps.version.outputs.branch_suffix}}"
+          branch: "node-extension-version-bump"
           commit-message: "${{steps.version.outputs.pr_title}}"
           delete-branch: true
-          title:  "${{steps.version.outputs.pr_title}}"
+          title: "${{steps.version.outputs.pr_title}}"
           body: "${{steps.version.outputs.pr_body}}"
 
       - name: Display output


### PR DESCRIPTION
### What does this PR do?

Adds a Github Workflow that runs daily to check if there are new releases to the Agent or Node Tracer. If there is a new release a PR is created to bump the versions in the Node Extension build script.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-4516

https://www.nuget.org/packages/Datadog.AzureAppServices.Node.Apm

### Additional Notes

* Handles new releases for just the Agent, just the Tracer, or both the Agent and Tracer
* If there are new releases created while a PR remains unmerged, the PR will be updated to reflect the latest releases

### Describe how to test/QA your changes

Update the trigger to `push` to verify that a PR is created with the appropriate version changes. It's helpful to have a test repo for this to prevent cluttering this repo with closed PRs.

<img width="699" alt="Screenshot 2024-04-12 at 10 22 48 AM" src="https://github.com/DataDog/datadog-aas-extension/assets/35278470/68e41752-f75e-496b-97ea-8a987ca5b898">

<img width="1084" alt="Screenshot 2024-04-12 at 10 26 33 AM" src="https://github.com/DataDog/datadog-aas-extension/assets/35278470/565eaa0d-43e1-4fab-b3b1-e9f3ab77773a">