### PR TITLE
[Node Extension] Remove Unused Environment Variables

### DIFF
--- a/node/src/applicationHost.xdt
+++ b/node/src/applicationHost.xdt
@@ -8,9 +8,6 @@
 
         <add name="DD_AGENT_HOST" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
-        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
-
         <add name="DD_APM_RECEIVER_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
@@ -18,7 +15,7 @@
         <add name="DD_APM_REMOTE_TAGGER" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
 
         <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the trace pipe on the agent  -->
 
         <add name="DD_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -28,12 +25,6 @@
 
         <add name="DD_DOGSTATSD_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-
-        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
-
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
 
         <add name="DD_EXTENSION_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_EXTENSION_PATH" value="%XDT_EXTENSIONPATH%" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -48,10 +39,7 @@
         <add name="DD_TRACE_AGENT_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_TRACE_AGENT_URL" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_AGENT_URL" value="unix:\\.\pipe\datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-
-        <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_AGENT_URL" value="unix:\\.\pipe\datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the trace pipe on the tracer  -->
 
         <add name="NODE_OPTIONS" value="--require=dd-trace\init %NODE_OPTIONS%" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
 

--- a/node/src/install.ps1
+++ b/node/src/install.ps1
@@ -40,11 +40,9 @@ $newConfigContent = $configContent -replace "ARCHITECTURE", "$architecture"
 # Save the modified content back to the file
 $newConfigContent | Set-Content -Path $configPath
 
-# Set the unique pipe names in the applicationHost.xdt file for traces and metrics
+# Set the unique pipe names in the applicationHost.xdt file for traces
 $tracePipeId=([guid]::NewGuid().ToString().ToUpper())
-$statsPipeId=([guid]::NewGuid().ToString().ToUpper())
 
-SetPipe ".\applicationHost.xdt" "uniqueStatsPipeId" "${statsPipeId}"
 SetPipe ".\applicationHost.xdt" "uniqueTracePipeId" "${tracePipeId}"
 
 Log("Install complete")


### PR DESCRIPTION
### What does this PR do?

Removes unused environment variables from the Node Extension.

### Motivation

Avoid confusion for what variables are used by the Tracer and the Agent for each runtime.

### Additional Notes

* Environment variables removed
  - `DD_AGENT_PIPE_NAME`
  - `DD_DOGSTATSD_PIPE_NAME`
  - `DD_DOGSTATSD_WINDOWS_PIPE_NAME`
  - `DD_TRACE_PIPE_NAME`
* Removed pipe `uniqueStatsPipeId` since DogStatsD metrics are send using UDP

### Describe how to test/QA your changes

Run pipeline with `RUNTIME=node` and verify that the build script succeeds and the package deployed to self monitoring sends traces, runtime metrics, and custom metrics to Datadog.