### PR TITLE
[Java Extension] Disable Remote Configuration and Remove Unused Environment Variables

### DIFF
--- a/java/src/applicationHost.xdt
+++ b/java/src/applicationHost.xdt
@@ -3,57 +3,58 @@
   <system.webServer>
     <runtime xdt:Transform="InsertIfMissing" >
       <environmentVariables xdt:Transform="InsertIfMissing">
-        <add name="DD_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		<add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_AAS_JAVA_EXTENSION_VERSION" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_AAS_JAVA_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
 
-        <add name="DD_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-
-        <add name="DD_TRACE_AGENT_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_AGENT_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-		
-        <add name="DD_TRACE_AGENT_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_AGENT_ARGS" value="--config %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-		
-        <add name="DD_DOGSTATSD_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-		
-        <add name="DD_DOGSTATSD_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_ARGS" value="start -c %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-
-        <add name="DD_TRACE_TRANSPORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_TRANSPORT" value="DATADOG-NAMED-PIPES" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-		
-        <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
-		
-        <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-		
-        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		<add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
-
-        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
-		
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
-		
         <add name="DD_AGENT_HOST" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		<add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
+
+        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+		    <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
 
         <add name="DD_APM_RECEIVER_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		<add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
+		    <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
         <add name="DD_APM_REMOTE_TAGGER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_APM_REMOTE_TAGGER" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
 
-        <add name="DD_AAS_JAVA_EXTENSION_VERSION" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_AAS_JAVA_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
+        <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
+
+        <add name="DD_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_DOGSTATSD_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_DOGSTATSD_ARGS" value="start -c %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_DOGSTATSD_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_DOGSTATSD_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
+
+        <add name="DD_DOGSTATSD_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+		    <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
+
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
 
         <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
-		
+
+        <add name="DD_TRACE_AGENT_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_TRACE_AGENT_ARGS" value="--config %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_TRACE_AGENT_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_TRACE_AGENT_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+		    <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/>		
+
+        <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="DD_TRACE_TRANSPORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_TRACE_TRANSPORT" value="DATADOG-NAMED-PIPES" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
 		<!-- Java Tracer Specific Variables -->
         <add name="JAVA_TOOL_OPTIONS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="JAVA_TOOL_OPTIONS" value="-javaagent:%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Tracer\dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.logFile=%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN\dd-java-agent.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>

--- a/java/src/applicationHost.xdt
+++ b/java/src/applicationHost.xdt
@@ -40,6 +40,9 @@
 
         <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
 
+        <add name="DD_REMOTE_CONFIGURATION_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
         <add name="DD_TRACE_AGENT_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_TRACE_AGENT_ARGS" value="--config %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 

--- a/java/src/applicationHost.xdt
+++ b/java/src/applicationHost.xdt
@@ -38,8 +38,6 @@
         <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
 
-        <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
-
         <add name="DD_REMOTE_CONFIGURATION_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 

--- a/java/src/applicationHost.xdt
+++ b/java/src/applicationHost.xdt
@@ -8,17 +8,14 @@
 
         <add name="DD_AGENT_HOST" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
-        <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		    <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
-
         <add name="DD_APM_RECEIVER_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 		    <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
         <add name="DD_APM_REMOTE_TAGGER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_APM_REMOTE_TAGGER" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
+        <add name="DD_APM_REMOTE_TAGGER" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
 
         <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
+        <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the trace pipe on the agent  -->
 
         <add name="DD_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -30,16 +27,13 @@
         <add name="DD_DOGSTATSD_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\dogstatsd.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
+        <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the dogstatsd pipe on the agent and the tracer -->
 
         <add name="DD_DOGSTATSD_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 		    <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_DOGSTATSD_WINDOWS_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd server variable -->
-
         <add name="DD_REMOTE_CONFIGURATION_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Disable remote config to avoid persistent polling of the remote-config state -->
 
         <add name="DD_TRACE_AGENT_ARGS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_TRACE_AGENT_ARGS" value="--config %XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog.yaml" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
@@ -51,10 +45,7 @@
 		    <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/>		
 
         <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-
-        <add name="DD_TRACE_TRANSPORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="DD_TRACE_TRANSPORT" value="DATADOG-NAMED-PIPES" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the trace pipe on the tracer  -->
 
 		<!-- Java Tracer Specific Variables -->
         <add name="JAVA_TOOL_OPTIONS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>

--- a/java/src/applicationHost.xdt
+++ b/java/src/applicationHost.xdt
@@ -9,7 +9,7 @@
         <add name="DD_AGENT_HOST" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
         <add name="DD_APM_RECEIVER_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		    <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
+        <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
         <add name="DD_APM_REMOTE_TAGGER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_APM_REMOTE_TAGGER" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
@@ -30,7 +30,7 @@
         <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the dogstatsd pipe on the agent and the tracer -->
 
         <add name="DD_DOGSTATSD_PORT" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		    <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
+        <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
 
         <add name="DD_REMOTE_CONFIGURATION_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Disable remote config to avoid persistent polling of the remote-config state -->
@@ -42,7 +42,7 @@
         <add name="DD_TRACE_AGENT_PATH" value="%XDT_EXTENSIONPATH%\vFOLDERUNKNOWN\Agent\datadog-trace-agent.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-		    <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/>		
+        <add name="DD_TRACE_LOG_PATH" value="%HOME%\LogFiles\datadog\java\vFOLDERUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Set the trace pipe on the tracer  -->


### PR DESCRIPTION
### What does this PR do?

* Disables remote configuration
* Removes unused environment variables from the Java Extension
* Removes hardcoded Datadog Agent log level
* Adds comments for where environment variables are used

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-4763 

* Prevent errors caused by persistent polling for remote-config state
```
2024-04-29 18:49:56 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:49:57 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:49:58 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:49:59 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:00 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:01 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:02 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:03 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:04 UTC | TRACE | INFO | (pkg/config/remote/client/client.go:332 in pollLoop) | retrying the first update of remote-config state (could not acquire agent auth token: unable to read authentication token file: open C:\home\SiteExtensions\DevelopmentVerification.DdJava.Apm\v1_1_500068358-prerelease\Agent\auth_token: The system cannot find the file specified.)
2024-04-29 18:50:05 UTC | TRACE | DEBUG | (pkg/trace/stats/concentrator.go:291 in flushNow) | Update oldestTs to 1714416590000000000
```
* Avoid confusion for what variables are used by the Tracer and the Agent for each runtime

### Additional Notes

* Environment variables removed
  - `DD_AGENT_PIPE_NAME`
  - `DD_DOGSTATSD_WINDOWS_PIPE_NAME`
  - `DD_TRACE_TRANSPORT`
* Set `DD_APM_REMOTE_TAGGER` to `false` instead of `0` to avoid issues with boolean resolution in Java

### Describe how to test/QA your changes

Run pipeline with `RUNTIME=java` and verify that the build script succeeds and the package deployed to self monitoring sends traces, runtime metrics, and custom metrics to Datadog.