### PR TITLE
[CI] Fetch the Latest Extension Release for each Runtime

### DIFF
--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -75,7 +75,7 @@ create-github-release:
     - apt-get update
     - apt-get install -y awscli
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.github-token --with-decryption --query "Parameter.Value" --out text)
-    - export LATEST_TAG=$(gh release list --repo DataDog/datadog-aas-extension --exclude-drafts --exclude-pre-releases --json tagName --jq '.[] | select(.tagName | contains("java")) | .tagName' --limit 1)
+    - export LATEST_TAG=$(gh release list --repo DataDog/datadog-aas-extension --exclude-drafts --exclude-pre-releases --json tagName --jq '.[] | select(.tagName | contains("java")) | .tagName' --order desc | head -n 1)
     - export TRACER_VERSION=$(grep -o 'TRACER_VERSION="[0-9.]*"' java/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
     - export AGENT_VERSION=$(grep -o 'AGENT_VERSION="[0-9.]*"' java/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
     - |

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -154,7 +154,7 @@ create-github-release:
     - apt-get update
     - apt-get install -y awscli
     - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.github-token --with-decryption --query "Parameter.Value" --out text)
-    - export LATEST_TAG=$(gh release list --repo DataDog/datadog-aas-extension --exclude-drafts --exclude-pre-releases --json tagName --jq '.[] | select(.tagName | contains("node")) | .tagName' --limit 1)
+    - export LATEST_TAG=$(gh release list --repo DataDog/datadog-aas-extension --exclude-drafts --exclude-pre-releases --json tagName --jq '.[] | select(.tagName | contains("node")) | .tagName' --order desc | head -n 1)
     - export TRACER_VERSION=$(grep -o 'TRACER_VERSION="[0-9.]*"' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
     - export AGENT_VERSION=$(grep -o 'AGENT_VERSION="[0-9.]*"' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
     - |


### PR DESCRIPTION
### What does this PR do?

Fetch the latest extension release for each runtime instead of the latest global release.

### Motivation

Automatically generate release notes based on the changes from the last release for the runtime. Previously the tag for the latest global release was fetched.

### Additional Notes

### Describe how to test/QA your changes

Run command locally and confirm that the latest release tag for each runtime is fetched.