### PR TITLE
[CI] Differentiate create-github-release Jobs for Node and Java

### DIFF
--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -57,7 +57,7 @@ update-self-monitoring-java-dev:
     - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows-java21-spring-self-monitoring-dev/siteextensions/DevelopmentVerification.DdJava.Apm" --properties "{}" --debug
     - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows-java21-spring-self-monitoring-dev"
 
-create-github-release:
+create-github-release-java:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/mirror/golang:1.22.0
   rules:
@@ -101,7 +101,7 @@ push-nuget-package-java-prod:
   stage: deploy
   needs:
     - build-nuget-packages-java
-    - create-github-release
+    - create-github-release-java
   script:
     - apt-get update
     - apt-get install -y awscli

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -136,7 +136,7 @@ update-self-monitoring-node-dev:
     - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring-dev"
     - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring-dev"
 
-create-github-release:
+create-github-release-node:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/mirror/golang:1.22.0
   rules:
@@ -180,7 +180,7 @@ push-nuget-package-node-prod:
   stage: deploy
   needs:
     - build-nuget-packages-node
-    - create-github-release
+    - create-github-release-node
   script:
     - apt-get update
     - apt-get install -y awscli


### PR DESCRIPTION
### What does this PR do?

Rename `create-github-release` jobs for node and java to `create-github-release-node` and `create-github-release-java`.

### Motivation

Error caused by multiple jobs with the same name.

<img width="1185" alt="Screenshot 2024-05-02 at 11 25 32 AM" src="https://github.com/DataDog/datadog-aas-extension/assets/35278470/26d02183-b89c-49e4-871a-c54ced03d603">

### Additional Notes

### Describe how to test/QA your changes

Create test branch and update `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH"` condition to `$CI_COMMIT_BRANCH == "<test-branch-name>"`. Verify that pipeline runs without errors