### PR TITLE
[.Net Version Bump] Bump agent to 7.54.1

### DIFF
--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -1,5 +1,5 @@
 DEVELOPMENT_VERSION="0.3.0-prerelease"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.0-1-x86_64.zip"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.1-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/INSTALL_SHA/windows-tracer-home.zip"
 
 

--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -1,5 +1,5 @@
 DEVELOPMENT_VERSION="0.3.0-prerelease"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.51.0-1-x86_64.zip"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.0-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/INSTALL_SHA/windows-tracer-home.zip"
 
 

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,5 +1,5 @@
 RELEASE_VERSION="2.53.200"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.0-1-x86_64.zip"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.1-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.53.2/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"

--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,5 +1,5 @@
 RELEASE_VERSION="2.53.200"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.51.0-1-x86_64.zip"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.0-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.53.2/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"


### PR DESCRIPTION
Update agent version to 7.54.1
Motivated by https://datadoghq.atlassian.net/browse/SLES-1702

A smoke test with the agent v7.54.1 :
<img width="1349" alt="Screenshot 2024-07-02 at 4 41 24 PM" src="https://github.com/DataDog/datadog-aas-extension/assets/5253430/9a89fb2c-2fe5-49bc-96fd-a9dc18881775">

