### PR TITLE
[.NET Extension] Update Default Behavior for DD_LOG_LEVEL and DD_REMOTE_CONFIGURATION_ENABLED

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,4 +1,4 @@
-RELEASE_VERSION="2.54.000"
+RELEASE_VERSION="2.54.001"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.1-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.54.0/windows-tracer-home.zip"
 

--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -36,6 +36,7 @@
         <add name="DD_APM_WINDOWS_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_TRACE_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_APM_REMOTE_TAGGER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="DD_REMOTE_CONFIGURATION_ENABLED" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 		
         <add name="DD_AGENT_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="DD_DOGSTATSD_PIPE_NAME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
@@ -77,6 +78,7 @@
         <add name="DD_APM_WINDOWS_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>	
         <add name="DD_TRACE_PIPE_NAME" value="datadogtrace-uniqueTracePipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="DD_APM_REMOTE_TAGGER" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Remote tagger is in the core agent, which is not included, so disable to improve startup time -->
+        <add name="DD_REMOTE_CONFIGURATION_ENABLED" value="false" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="DD_AGENT_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (LEGACY) -->
         <add name="DD_DOGSTATSD_PIPE_NAME" value="dogstatsd-uniqueStatsPipeId" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Dogstatsd client variable (CURRENT) -->
@@ -85,8 +87,6 @@
         <add name="DD_DOGSTATSD_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
         <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
-
-        <add name="DD_LOG_LEVEL" value="WARN" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/> <!-- Keep agent logs reasonably quiet for v1, until logging levels are settled in tracer -->
 
       </environmentVariables>
     </runtime>


### PR DESCRIPTION
### What does this PR do?

* Removes the hard coded value for `DD_LOG_LEVEL` in `applicationHost.xdt` since it prevents other log levels from being set
* Sets `DD_REMOTE_CONFIGURATION_ENABLED` to `false` by default 
* Bumps .NET Extension version to 2.54.001

### Motivation

* Allow for better troubleshooting by setting `DD_LOG_LEVEL` to `debug`
* Disable remote config by default to prevent slow loading times

### Additional Notes

Remote Config is enabled by default as of Datadog Agent version 7.47.0 but requires an org level setting to be enabled and the API Key to have remote config enabled. I inadvertently had this setup in a test environment and experienced slow loading times. Let's disable remote config by default since it's not supported in the AAS environment.

https://github.com/DataDog/datadog-agent/releases/tag/7.47.0

<img width="889" alt="Screenshot 2024-07-17 at 8 57 11 AM" src="https://github.com/user-attachments/assets/1f80d62d-331b-44b9-93fe-410f56469221">

### Describe how to test/QA your changes
