### PR TITLE
Add permissions to GitHub Actions

### DIFF
--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -10,6 +10,9 @@ jobs:
   tag_version_bump_commit:
     if: startsWith(github.event.head_commit.message, '[.Net Version Bump]')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create release
+      actions: read # read secrets
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -20,6 +20,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
+      actions: read # read secrets
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/java_extension_update_versions.yml
+++ b/.github/workflows/java_extension_update_versions.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
+      actions: read # read secrets
 
     steps:
       - name: Checkout

--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
+      actions: read # read secrets
 
     steps:
       - name: Checkout

--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   update_extension:
+    permissions:
+      contents: read
+      actions: read # read secrets
+      packages: write # pushing to ghcr.io
+
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Our AAS release was failing with a permission error, and I realised that the persmissions for the project had been changed: 

![image](https://github.com/user-attachments/assets/75074cf6-c75c-4a92-8e9d-c7f6e7e07d96)

This will cause all our automations to fail, so I have temporarily reverted the changes. Adding these permissions _should_ allow us to re-enable the read-only by default permissions once merged. We will need to keep the "create PRs" checked though