### PR TITLE
Add standardized GitHub Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,50 @@
+name: "Bug Report (Low Priority)"
+description: "Create a public Bug Report. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult."
+title: "[BUG]: "
+labels: type:bug
+body:
+  - type: input
+    attributes:
+      label: AAS extension version used
+      description: "Version of the AAS extension used"
+      placeholder: 1.9.0
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Operating system and platform
+      description: "The operating system (Windows, Linux, Ubuntu) and platform (arm64, x64) on which you are experiencing the issue"
+      placeholder: Windows (x64), Linux (arm64)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Language
+      description: "What language is your application written in?"
+      placeholder: ".NET, Java, Node.js"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Language Runtime Version
+      description: "Please provide the version of the language runtime (.NET TFM, `java --version`, `node --version)"
+      placeholder: "net462, net9.0"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug Report
+      description: Please add a clear and concise description of the bug here
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Code
+      description: Please add code here to help us reproduce the problem
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm
+    about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private.
+  - name: Feature Request (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1260825272270=pt_apm_category_feature_request
+    about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,59 @@
+name: Feature Request (Low Priority)
+description: Create a public Feature Request. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult.
+title: "[FEATURE]: "
+labels: type:enhancement
+body:
+  - type: input
+    attributes:
+      label: Framework or Library Name
+      description: "If your feature request is to add instrumentation support for a library please provide the name here"
+      placeholder: "ASP.NET MVC, StackExchange.Redis"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Library Type
+      description: "If your feature request is to add instrumentation support for a library please provide the version you use"
+      placeholder: "web framework, data store, cache"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Library Version(s)
+      description: "If your feature request is to add instrumentation support for a library please provide the version you use"
+      placeholder: 5.2
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: |
+        Please add a clear and concise description of your problem.
+        E.g. I'm unable to instrument my database queries...
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here
+    validations:
+      required: false
+


### PR DESCRIPTION
Adds the standardized GitHub Issue template now used in the various `dd-trace-*` libraries into this one as well as the GitHub Issues here usually apply to those repositories as well.

I copied the `dd-trace-dotnet` template with some small changes to allow for the inclusion of Java/Node.js issues.

https://datadoghq.atlassian.net/browse/AIDM-523