### PR TITLE
chore: Upgrade Agents and Tracers

### DIFF
--- a/dotnet/build-packages.sh
+++ b/dotnet/build-packages.sh
@@ -1,5 +1,5 @@
 RELEASE_VERSION="3.8.000"
-AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.54.1-1-x86_64.zip"
+AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.61.0-1-x86_64.zip"
 TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v3.8.0/windows-tracer-home.zip"
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"

--- a/java/scripts/build-packages.sh
+++ b/java/scripts/build-packages.sh
@@ -3,8 +3,8 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.55.3"
-TRACER_VERSION="1.38.1"
+AGENT_VERSION="7.61.0"
+TRACER_VERSION="1.45.1"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"

--- a/node/scripts/build-packages.sh
+++ b/node/scripts/build-packages.sh
@@ -3,8 +3,8 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.55.3"
-TRACER_VERSION="4.45.0"
+AGENT_VERSION="7.61.0"
+TRACER_VERSION="4.55.0"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"


### PR DESCRIPTION
Agent: [7.61.0](https://github.com/DataDog/datadog-agent/releases/tag/7.61.0)
Java: [1.45.0](https://github.com/DataDog/dd-trace-java/releases/tag/v1.45.1)
Node: [4.55.0](https://github.com/DataDog/dd-trace-js/releases/tag/v4.55.0)
.NET: [3.8.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.8.0) (already upgraded)