### PR TITLE
chore: Upgrade Java and Node Tracers and Agents

### DIFF
--- a/java/scripts/build-packages.sh
+++ b/java/scripts/build-packages.sh
@@ -4,7 +4,7 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
 fi
 
 AGENT_VERSION="7.60.1"
-TRACER_VERSION="1.45.1"
+TRACER_VERSION="1.46.0"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"

--- a/java/scripts/build-packages.sh
+++ b/java/scripts/build-packages.sh
@@ -3,8 +3,8 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.55.3"
-TRACER_VERSION="1.38.1"
+AGENT_VERSION="7.61.0"
+TRACER_VERSION="1.45.1"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"

--- a/java/scripts/build-packages.sh
+++ b/java/scripts/build-packages.sh
@@ -3,7 +3,7 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.61.0"
+AGENT_VERSION="7.60.1"
 TRACER_VERSION="1.45.1"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"

--- a/node/scripts/build-packages.sh
+++ b/node/scripts/build-packages.sh
@@ -3,7 +3,7 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.61.0"
+AGENT_VERSION="7.60.1"
 TRACER_VERSION="4.55.0"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"

--- a/node/scripts/build-packages.sh
+++ b/node/scripts/build-packages.sh
@@ -3,8 +3,8 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
     exit 1
 fi
 
-AGENT_VERSION="7.55.3"
-TRACER_VERSION="4.45.0"
+AGENT_VERSION="7.61.0"
+TRACER_VERSION="4.55.0"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"


### PR DESCRIPTION
Agent: [7.60.1](https://github.com/DataDog/datadog-agent/releases/tag/7.60.1) (not the latest, which no longer allows us to disable remote tagging)
Java: [1.46.0](https://github.com/DataDog/dd-trace-java/releases/tag/v1.46.0)
Node: [5.35.0](https://github.com/DataDog/dd-trace-js/releases/tag/v5.35.0)