### PR TITLE
Fix dotnet dev builds

### DIFF
--- a/.gitlab/dotnet.yml
+++ b/.gitlab/dotnet.yml
@@ -1,19 +1,4 @@
-dotnet-package-dev:
-  tags: ["runner:main"]
-  image: mcr.microsoft.com/dotnet/core/sdk:3.1
-  rules:
-    - if: $RUNTIME != "node" && $RUNTIME != "java"
-  stage: build
-  script:
-    - echo "Installing dependencies"
-    - apt-get update
-    - apt-get install unzip
-    - bash ./dotnet/build-packages-dev.sh
-  artifacts:
-    expire_in: 1 weeks
-    paths:
-      - package
-dotnet-package-prod:
+dotnet-package:
   tags: ["runner:main"]
   image: mcr.microsoft.com/dotnet/core/sdk:3.1
   rules:

--- a/dotnet/build-packages-dev.sh
+++ b/dotnet/build-packages-dev.sh
@@ -1,6 +1,6 @@
 DEVELOPMENT_VERSION="0.3.0-prerelease"
 AGENT_DOWNLOAD_URL="http://s3.amazonaws.com/dsd6-staging/windows/agent7/buildpack/agent-binaries-7.61.0-1-x86_64.zip"
-TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v3.8.0/windows-tracer-home.zip"
+TRACER_DOWNLOAD_URL="https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/INSTALL_SHA/windows-tracer-home.zip"
 
 
 echo "Downloading tracer from ${TRACER_DOWNLOAD_URL}"


### PR DESCRIPTION
https://github.com/DataDog/datadog-aas-extension/pull/303 stopped using the latest .NET dev builds, which broke the deployment to the AAS release gate environment, and 

The dev script as currently written, isn't _intended_ to be built from GitLab. It's meant to be used by the `update_aas_extension.yml` github action which does some pre-processing etc. 

This absolutely needs re-visiting, but right now we just need to unblock the .NET releases 😅 