### PR TITLE
Remove agent version bumps from node and java extension workflows

### DIFF
--- a/.github/workflows/java_extension_update_versions.yml
+++ b/.github/workflows/java_extension_update_versions.yml
@@ -19,17 +19,6 @@ jobs:
       - name: Modify build-packages
         id: version
         run: |
-          CURRENT_AGENT_VERSION=$(awk '/AGENT_VERSION=/{print}' java/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
-          AGENT_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/datadog-agent/releases")
-          AGENT_VERSION=$(echo "$AGENT_RESPONSE" | jq -r --arg pattern "7\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
-
-          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ]; then
-            echo "Updating agent to version: $AGENT_VERSION"
-            sed -i -e "s/AGENT_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/AGENT_VERSION=\"$AGENT_VERSION\"/" java/scripts/build-packages.sh
-            PR_BODY="Bumps the agent version to $AGENT_VERSION for the Java Extension."
-            PR_TITLE="[Java Extension] Bump agent to $AGENT_VERSION"
-          fi
-
           CURRENT_TRACER_VERSION=$(awk '/TRACER_VERSION=/{print}' java/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
           TRACER_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/dd-trace-java/releases")
           TRACER_VERSION=$(echo "$TRACER_RESPONSE" | jq -r --arg pattern "v1\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name | ltrimstr("v")' | sort -V | tail -n 1)
@@ -39,11 +28,6 @@ jobs:
             sed -i -e "s/TRACER_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/TRACER_VERSION=\"$TRACER_VERSION\"/" java/scripts/build-packages.sh
             PR_BODY="Bumps the tracer version to $TRACER_VERSION for the Java Extension."
             PR_TITLE="[Java Extension] Bump tracer to $TRACER_VERSION"
-          fi
-
-          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ] && [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
-            PR_BODY="Bumps the agent version to $AGENT_VERSION and the tracer version to $TRACER_VERSION for the Java Extension."
-            PR_TITLE="[Java Extension] Bump agent to $AGENT_VERSION and tracer to $TRACER_VERSION"
           fi
 
           echo "pr_body=$PR_BODY" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -19,17 +19,6 @@ jobs:
       - name: Modify build-packages
         id: version
         run: |
-          CURRENT_AGENT_VERSION=$(awk '/AGENT_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
-          AGENT_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/datadog-agent/releases")
-          AGENT_VERSION=$(echo "$AGENT_RESPONSE" | jq -r --arg pattern "7\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
-
-          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ]; then
-            echo "Updating agent to version: $AGENT_VERSION"
-            sed -i -e "s/AGENT_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/AGENT_VERSION=\"$AGENT_VERSION\"/" node/scripts/build-packages.sh
-            PR_BODY="Bumps the agent version to $AGENT_VERSION for the Node Extension."
-            PR_TITLE="[Node Extension] Bump agent to $AGENT_VERSION"
-          fi
-
           CURRENT_TRACER_VERSION=$(awk '/TRACER_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
           TRACER_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/dd-trace-js/releases")
           TRACER_VERSION=$(echo "$TRACER_RESPONSE" | jq -r --arg pattern "v4\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name | ltrimstr("v")' | sort -V | tail -n 1)
@@ -39,11 +28,6 @@ jobs:
             sed -i -e "s/TRACER_VERSION=\"[0-9]*\.[0-9]*\.[0-9]*\"/TRACER_VERSION=\"$TRACER_VERSION\"/" node/scripts/build-packages.sh
             PR_BODY="Bumps the tracer version to $TRACER_VERSION for the Node Extension."
             PR_TITLE="[Node Extension] Bump tracer to $TRACER_VERSION"
-          fi
-
-          if [ "$CURRENT_AGENT_VERSION" != "$AGENT_VERSION" ] && [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
-            PR_BODY="Bumps the agent version to $AGENT_VERSION and the tracer version to $TRACER_VERSION for the Node Extension."
-            PR_TITLE="[Node Extension] Bump agent to $AGENT_VERSION and tracer to $TRACER_VERSION"
           fi
 
           echo "pr_body=$PR_BODY" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Following this change in the agent the Remote Tagger is always enabled, resulting in high memory usage in Azure App Service environments.
https://github.com/DataDog/datadog-agent/pull/31096

For now will stay pinned to Agent version 7.60.1
https://github.com/DataDog/datadog-aas-extension/pull/304