### PR TITLE
Use v5 Release Line for Datadog Node Tracer

### DIFF
--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           CURRENT_TRACER_VERSION=$(awk '/TRACER_VERSION=/{print}' node/scripts/build-packages.sh | awk -F '=' '{print $2}' | tr -d '"')
           TRACER_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/dd-trace-js/releases")
-          TRACER_VERSION=$(echo "$TRACER_RESPONSE" | jq -r --arg pattern "v4\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name | ltrimstr("v")' | sort -V | tail -n 1)
+          TRACER_VERSION=$(echo "$TRACER_RESPONSE" | jq -r --arg pattern "v5\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name | ltrimstr("v")' | sort -V | tail -n 1)
 
           if [ "$CURRENT_TRACER_VERSION" != "$TRACER_VERSION" ]; then
             echo "Updating tracer to version: $TRACER_VERSION"

--- a/node/scripts/build-packages.sh
+++ b/node/scripts/build-packages.sh
@@ -4,7 +4,7 @@ if [[ -z ${RELEASE_VERSION+x} ]] || [[ -z ${DEVELOPMENT_VERSION+x} ]]; then
 fi
 
 AGENT_VERSION="7.55.3"
-TRACER_VERSION="4.45.0"
+TRACER_VERSION="5.35.0"
 
 echo "Building version ${RELEASE_VERSION} for prod environment"
 echo "Building version ${DEVELOPMENT_VERSION} for dev environment"


### PR DESCRIPTION
Node 16 is EOL. Since the v5 release line for the Datadog Node Tracer supports Node 18 and later versions, we can pin the Datadog Node Extension to this v5 release line.

https://github.com/Azure/app-service-linux-docs/blob/master/Runtime_Support/node_support.md#how-to-update-your-app-to-target-a-different-version-of-node

<img width="470" alt="Screenshot 2025-02-03 at 9 35 33 AM" src="https://github.com/user-attachments/assets/2a5d7a5e-bdd7-4799-864d-e44feecc2e75" />

https://github.com/DataDog/dd-trace-js?tab=readme-ov-file#version-release-lines-and-maintenance
<img width="646" alt="Screenshot 2025-02-03 at 9 35 46 AM" src="https://github.com/user-attachments/assets/9e636920-01c3-417a-a9e1-e017ae99dcc1" />

https://datadoghq.atlassian.net/browse/SVLS-4913
