### PR TITLE
Bump go image in GitLab CI to 1.23.5

### DIFF
--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -62,7 +62,7 @@ update-self-monitoring-java-dev:
 
 create-github-release-java:
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/golang:1.22.0
+  image: registry.ddbuild.io/images/mirror/golang:1.23.5
   rules:
     - if: $RUNTIME == "java" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -138,7 +138,7 @@ update-self-monitoring-node-dev:
 
 create-github-release-node:
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/golang:1.22.0
+  image: registry.ddbuild.io/images/mirror/golang:1.23.5
   rules:
     - if: $RUNTIME == "node" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy


### PR DESCRIPTION
Github CLI is installed with Go and the job to create a Github release is failing on Go 1.22.0. This change updates the jobs in these GitLab CI pipelines to use the image for [golang:1.23.5](https://github.com/DataDog/images/blob/d8d077562f91e5579d79503974d4c13ed4f42c68/mirror.yaml#L1788).

```
$ git clone https://github.com/cli/cli.git gh-cli
Cloning into 'gh-cli'...
$ cd gh-cli
$ make install
GOOS= GOARCH= GOARM= GOFLAGS= CGO_ENABLED= go build -o script/build script/build.go
go: go.mod requires go >= 1.23.0 (running go 1.22.0; GOTOOLCHAIN=local)
make: *** [Makefile:21: script/build] Error 1
```