### PR TITLE
Roll back go image in gitlab ci to 1.23.4

### DIFF
--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -62,7 +62,7 @@ update-self-monitoring-java-dev:
 
 create-github-release-java:
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/golang:1.23.5
+  image: registry.ddbuild.io/images/mirror/golang:1.23.4
   rules:
     - if: $RUNTIME == "java" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -138,7 +138,7 @@ update-self-monitoring-node-dev:
 
 create-github-release-node:
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/golang:1.23.5
+  image: registry.ddbuild.io/images/mirror/golang:1.23.4
   rules:
     - if: $RUNTIME == "node" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy


### PR DESCRIPTION
Github CLI is installed with Go and the job to create a Github release is failing on Go 1.22.0. This change updates the jobs in these GitLab CI pipelines to use the image for [golang:1.23.4](https://github.com/DataDog/images/blob/14b94f5ad1809f5c7239a4359dd22157f3638509/mirror.yaml#L1808) due to an issue with pulling the mirrored `golang:1.23.5` image.

Follows https://github.com/DataDog/datadog-aas-extension/pull/316