### PR TITLE
Track the install type

### DIFF
--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -88,6 +88,7 @@
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
         <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
 
+        <add name="DD_INSTRUMENTATION_INSTALL_TYPE " value="aas_extension" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </environmentVariables>
     </runtime>
   </system.webServer>

--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -88,7 +88,7 @@
         <add name="DD_APM_RECEIVER_PORT" value="0" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- Needed to force no port conflicts -->
         <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
 
-        <add name="DD_INSTRUMENTATION_INSTALL_TYPE " value="aas_extension" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="DD_INSTRUMENTATION_INSTALL_TYPE" value="aas_extension" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </environmentVariables>
     </runtime>
   </system.webServer>


### PR DESCRIPTION
In https://github.com/DataDog/dd-trace-dotnet/pull/6716 we started sending known "install" sources - this would add another source