### PR TITLE
feat(data-pipeline): add DD_TRACE_DATA_PIPELINE_ENABLED environment variable

### DIFF
--- a/dotnet/content/applicationHost.xdt
+++ b/dotnet/content/applicationHost.xdt
@@ -89,6 +89,8 @@
         <add name="DD_AAS_DOTNET_EXTENSION_VERSION" value="vUNKNOWN" xdt:Locator="Match(name)" xdt:Transform="Insert"/> <!-- For troubleshooting and tagging traces -->
 
         <add name="DD_INSTRUMENTATION_INSTALL_TYPE" value="aas_extension" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+
+        <add name="DD_TRACE_DATA_PIPELINE_ENABLED" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>
     </runtime>
   </system.webServer>


### PR DESCRIPTION
We only want to enable data pipeline for AAS to start with.

This change follows existing approach to enable changes like

```
        <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
```
