### PR TITLE
Powershell Extension Installer fixes

### DIFF
--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -46,12 +46,8 @@ if ($Password -eq "ambient") {
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-
-
 $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $Username, $Password)))
 $userAgent = "powershell/1.0"
-
-
 
 $siteApiUrl="https://management.azure.com/subscriptions/${SubscriptionId}/resourceGroups/${ResourceGroup}/providers/Microsoft.Web/sites/${SiteName}"
 $siteConfig = az rest -m GET --header "Accept=application/json" -u "${siteApiUrl}?api-version=2019-08-01" | ConvertFrom-Json

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -137,7 +137,7 @@ else {
 	}
 	else {
         Write-Output "Attempting to install latest ${Extension}"
-		Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
+        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
 		Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
 	}
 }

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -137,7 +137,7 @@ else {
 	}
 	else {
         Write-Output "Attempting to install latest ${Extension}"
-        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{ "Authorization"=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
+        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
 		Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
 	}
 }

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -46,15 +46,19 @@ if ($Password -eq "ambient") {
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$baseApiUrl = "https://${SiteName}.scm.azurewebsites.net/api"
+
 
 $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $Username, $Password)))
 $userAgent = "powershell/1.0"
 
-$siteExtensionsBase="${baseApiUrl}/siteextensions"
-$siteExtensionManage="${baseApiUrl}/siteextensions/${Extension}"
+
 
 $siteApiUrl="https://management.azure.com/subscriptions/${SubscriptionId}/resourceGroups/${ResourceGroup}/providers/Microsoft.Web/sites/${SiteName}"
+$siteConfig = az rest -m GET --header "Accept=application/json" -u "${siteApiUrl}?api-version=2019-08-01" | ConvertFrom-Json
+
+$baseApiUrl = "https://$($siteConfig.properties.enabledHostNames -like "*.scm.*")/api"
+$siteExtensionsBase="${baseApiUrl}/siteextensions"
+$siteExtensionManage="${baseApiUrl}/siteextensions/${Extension}"
 
 # Stop the web app
 # https://docs.microsoft.com/en-us/rest/api/appservice/webapps/stop
@@ -137,8 +141,8 @@ else {
 	}
 	else {
         Write-Output "Attempting to install latest ${Extension}"
-        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
-        Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
+        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{ "Authorization"=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
+		Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
 	}
 }
 

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -137,7 +137,7 @@ else {
 	}
 	else {
         Write-Output "Attempting to install latest ${Extension}"
-        Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
+		Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
 		Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
 	}
 }

--- a/management-scripts/extension/update-all-site-extensions.ps1
+++ b/management-scripts/extension/update-all-site-extensions.ps1
@@ -40,7 +40,7 @@ $allSites=az webapp list -g $ResourceGroup | ConvertFrom-Json
 Foreach($webapp in @($allSites)) {
 	
 	$siteName=$webapp.name
-	$baseApiUrl = "https://${siteName}.scm.azurewebsites.net/api"
+	$baseApiUrl = "https://$($webapp.enabledHostNames -like "*.scm.*")/api"
 	$siteExtensionsBase="${baseApiUrl}/siteextensions"
 	$siteExtensionManage="${baseApiUrl}/siteextensions/${extension}"
 


### PR DESCRIPTION
### What this does:
This fixes a breakage that occured when azure started to introduce secure hostnames which added a hash to to every azure app subdomain. In the previous script we relied on the subdomain just consisting of the app name. Additionally azure changed the scm domain to include the region of the app. 

More details about that here:
https://techcommunity.microsoft.com/blog/appsonazureblog/public-preview-creating-web-app-with-a-unique-default-hostname/4156353

To solve this I made modifications to one script to fetch the configuration data of the the web app which includes the domain names assigned to it. The other script had been querying configuration data before so I leveraged that to set the the base site api to the proper domain in the the array. 

The application domain and the scm domain. I used a filter to find it within the array. This change also does not break any user workflow as there are no additional parameters required. 

I have test both scripts end to end and they appear to be working as intended. 
It was able to install and check for updates successfuly.
