### PR TITLE
Simplify the .NET AAS extension update, and add new app

### DIFF
--- a/.github/workflows/update_aas_extension.yml
+++ b/.github/workflows/update_aas_extension.yml
@@ -112,6 +112,7 @@ jobs:
               "dd-dotnet-latest-build"
               "dd-dotnet-latest-build-stats"
               "dd-dotnet-latest-build-profiler-only"
+              "dd-dotnet-latest-data-pipeline"
               "dd-dotnet-profiler-backend-test-latest-build"
               "dd-dotnet-security-aspnetcore"
             )


### PR DESCRIPTION
I wanted to add a new app to this list. Rather than a bunch of copy-paste, decided to refactor the bash a bit _first_, and then add the new app to the pipeline.

I've done a manual test, and it works as expected 🙂 