### PR TITLE
Fix .NET build

### DIFF
--- a/.gitlab/dotnet.yml
+++ b/.gitlab/dotnet.yml
@@ -1,6 +1,6 @@
 dotnet-package:
   tags: ["runner:main"]
-  image: mcr.microsoft.com/dotnet/core/sdk:3.1
+  image: mcr.microsoft.com/dotnet/sdk:8.0
   rules:
     - if: $RUNTIME != "node" && $RUNTIME != "java"
   stage: build


### PR DESCRIPTION
Updates the version of the SDK (and the build image) used to build the AAS extension.

The current .NET build is using a very old, unsupported version of the SDK. What's more, this is now failing because the debian buster image that the 3.1 SDK uses is 1 year EOL, and has had its packages removed:

```
$ apt-get update
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
Ign:3 http://deb.debian.org/debian buster-updates InRelease
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 146.75.38.132 80]
Err:5 http://deb.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 146.75.38.132 80]
Err:6 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 146.75.38.132 80]
Reading package lists...
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```