### PR TITLE
[SINT-3853] update last_release step and dd-octo-sts policies

### DIFF
--- a/.github/chainguard/self.create-version-bump-pr.create-pr.sts.yaml
+++ b/.github/chainguard/self.create-version-bump-pr.create-pr.sts.yaml
@@ -9,4 +9,5 @@ claim_pattern:
   job_workflow_ref: DataDog/datadog-aas-extension/\.github/workflows/create_version_bump_PR\.yml@refs/heads/master
 
 permissions:
+  contents: write
   pull_requests: write

--- a/.github/chainguard/self.java-extension-update-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.java-extension-update-versions.create-pr.sts.yaml
@@ -9,4 +9,5 @@ claim_pattern:
   job_workflow_ref: DataDog/datadog-aas-extension/\.github/workflows/java_extension_update_versions\.yml@refs/heads/master
 
 permissions:
+  contents: write
   pull_requests: write

--- a/.github/chainguard/self.node-extension-update-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.node-extension-update-versions.create-pr.sts.yaml
@@ -9,4 +9,5 @@ claim_pattern:
   job_workflow_ref: DataDog/datadog-aas-extension/\.github/workflows/node_extension_update_versions\.yml@refs/heads/master
 
 permissions:
+  contents: write
   pull_requests: write

--- a/.github/workflows/create_version_bump_PR.yml
+++ b/.github/workflows/create_version_bump_PR.yml
@@ -54,6 +54,7 @@ jobs:
           owner: DataDog
           repo: datadog-agent
           excludes: prerelease, draft
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Modify build-packages"
         id: "versions"


### PR DESCRIPTION
# Intent
Follow-up of https://github.com/DataDog/datadog-aas-extension/pull/373

## Change in .github/workflows/create_version_bump_PR.yml
This is meant to address this failure: https://github.com/DataDog/datadog-aas-extension/actions/runs/16801429605/job/47583548105

https://github.com/pozetroninc/github-action-get-latest-release?tab=readme-ov-file#configuration explains how this fixes rate limits issues.

## Change in .github/chainguard/*.sts.yaml
This is meant to address this failure: https://github.com/DataDog/datadog-aas-extension/actions/runs/16801429605/job/47588192070