### PR TITLE
fix: Use correct Octo policy for Node Extension 

### DIFF
--- a/.github/workflows/java_extension_update_versions.yml
+++ b/.github/workflows/java_extension_update_versions.yml
@@ -1,6 +1,7 @@
 name: Update Versions for Java Extension
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 14 * * *" # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
 

--- a/.github/workflows/node_extension_update_versions.yml
+++ b/.github/workflows/node_extension_update_versions.yml
@@ -1,6 +1,7 @@
 name: Update Versions for Node Extension
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 14 * * *" # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
 


### PR DESCRIPTION
Node Extension update action using the incorrect Octo policy:

```
Run DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80
  with:
    scope: DataDog/datadog-aas-extension
    policy: self.java-extension-update-versions.create-pr
    domain: webhooks.build.datadoghq.com
    audience: dd-octo-sts
Attempt 1 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: claim \"job_workflow_ref\" did not match \"^DataDog/datadog-aas-extension/\\\\.github/workflows/java_extension_update_versions\\\\.yml@refs/heads/master$\"","details":[]}
Attempt 2 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: claim \"job_workflow_ref\" did not match \"^DataDog/datadog-aas-extension/\\\\.github/workflows/java_extension_update_versions\\\\.yml@refs/heads/master$\"","details":[]}
Attempt 3 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: claim \"job_workflow_ref\" did not match \"^DataDog/datadog-aas-extension/\\\\.github/workflows/java_extension_update_versions\\\\.yml@refs/heads/master$\"","details":[]}
```

Also updates the Node Extension and Java Extension update workflows to be run manually for testing.

Tried to test on the feature branch but it looks like the Octo policy only works when the action is run from the master branch.
```
Run DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80
  with:
    scope: DataDog/datadog-aas-extension
    policy: self.node-extension-update-versions.create-pr
    domain: webhooks.build.datadoghq.com
    audience: dd-octo-sts
Attempt 1 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: subject \"repo:DataDog/datadog-aas-extension:ref:refs/heads/duncan-harvey/node-extension-octo-policy\" did not match \"repo:DataDog/datadog-aas-extension:ref:refs/heads/master\"","details":[]}
Attempt 2 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: subject \"repo:DataDog/datadog-aas-extension:ref:refs/heads/duncan-harvey/node-extension-octo-policy\" did not match \"repo:DataDog/datadog-aas-extension:ref:refs/heads/master\"","details":[]}
Attempt 3 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: subject \"repo:DataDog/datadog-aas-extension:ref:refs/heads/duncan-harvey/node-extension-octo-policy\" did not match \"repo:DataDog/datadog-aas-extension:ref:refs/heads/master\"","details":[]}
```