### PR TITLE
fix: use v143 for Visual Studio Platform Toolset in Node Extension CI Pipeline

### DIFF
--- a/node/AgentProcessManager/AgentProcessManager.vcxproj
+++ b/node/AgentProcessManager/AgentProcessManager.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Resolves error below when building Node Extension IIS Module.

https://gitlab.ddbuild.io/DataDog/datadog-aas-extension/-/jobs/1087232102

```
c:\build>REM find the visual studio tools 
c:\build>call c:\devtools\vstudio\Common7\tools\vsdevcmd.bat 
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.14.11
** Copyright (c) 2025 Microsoft Corporation
**********************************************************************
MSBuild version 17.14.18+a338add32 for .NET Framework
Build started 8/19/2025 2:32:16 PM.
Project "c:\build\node\AgentProcessManager\AgentProcessManager.sln" on node 1 (default targets).
ValidateSolutionConfiguration:
  Building solution configuration "Release|x64".
Project "c:\build\node\AgentProcessManager\AgentProcessManager.sln" (1) is building "c:\build\node\AgentProcessManager\AgentProcessManager.vcxproj" (2) on node 1 (default targets).
c:\devtools\vstudio\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(463,5): error MSB8020: The build tools for Visual Studio 2019 (Platform Toolset = 'v142') cannot be found. To build using the v142 build tools, please install Visual Studio 2019 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [c:\build\node\AgentProcessManager\AgentProcessManager.vcxproj]
Done Building Project "c:\build\node\AgentProcessManager\AgentProcessManager.vcxproj" (default targets) -- FAILED.
Done Building Project "c:\build\node\AgentProcessManager\AgentProcessManager.sln" (default targets) -- FAILED.
Build FAILED.
"c:\build\node\AgentProcessManager\AgentProcessManager.sln" (default target) (1) ->
"c:\build\node\AgentProcessManager\AgentProcessManager.vcxproj" (default target) (2) ->
(PrepareForBuild target) -> 
  c:\devtools\vstudio\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(463,5): error MSB8020: The build tools for Visual Studio 2019 (Platform Toolset = 'v142') cannot be found. To build using the v142 build tools, please install Visual Studio 2019 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [c:\build\node\AgentProcessManager\AgentProcessManager.vcxproj]
```