### PR TITLE
Fix automatic publishing of .NET releases 

### DIFF
--- a/.github/chainguard/self.auto-tag-and-release.master.sts.yaml
+++ b/.github/chainguard/self.auto-tag-and-release.master.sts.yaml
@@ -1,0 +1,14 @@
+# Policy for: .github/workflows/auto_tag_and_release.yml in DataDog/datadog-aas-extension
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-aas-extension:ref:refs/heads/master
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/datadog-aas-extension/\.github/workflows/auto_tag_and_release\.yml@refs/heads/master
+  ref: refs/heads/master
+  ref_protected: "true"
+  repository: DataDog/datadog-aas-extension
+
+permissions:
+  contents: write

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -11,6 +11,7 @@ jobs:
     if: startsWith(github.event.head_commit.message, '[.Net Version Bump]')
     runs-on: ubuntu-latest
     permissions:
+      contents: read # Needed for actions/checkout to use GITHUB_TOKEN
       id-token: write # Needed to federate tokens for dd-octo-sts
     steps:
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -41,6 +41,7 @@ jobs:
           draft: true
           name: "${{steps.version.outputs.tagname}}"
           tag_name: "${{steps.version.outputs.tagname}}"
+          target_commitish: ${{ github.sha }}
           prerelease: false
           body: |
             ## Versions included

--- a/.github/workflows/auto_tag_and_release.yml
+++ b/.github/workflows/auto_tag_and_release.yml
@@ -11,17 +11,18 @@ jobs:
     if: startsWith(github.event.head_commit.message, '[.Net Version Bump]')
     runs-on: ubuntu-latest
     permissions:
-      contents: write # create release
-      actions: read # read secrets
+      id-token: write # Needed to federate tokens for dd-octo-sts
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-aas-extension
+          policy: self.auto-tag-and-release.master
+
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - name: "Configure Git Credentials"
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: "Create and push git tag"
+      - name: "Extract version info"
         id: version
         run: |
           VERSION="$(grep -o -e RELEASE_VERSION\=\"[0-9]*\.[0-9]*\.[0-9]*  dotnet/build-packages.sh | sed 's/RELEASE_VERSION="//')"
@@ -32,10 +33,10 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=tracer_version::$TRACER_VERSION"
           echo "::set-output name=agent_version::$AGENT_VERSION"
-          git tag "$TAGNAME"
-          git push origin "$TAGNAME"
       - name: Create Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         with:
           draft: true
           name: "${{steps.version.outputs.tagname}}"


### PR DESCRIPTION
- Add an STS configuration for the release creation
- Stop pre-pushing the tag, and instead allow for creation during release _publish_ (like we do on dd-trace-dotnet)
  - This ensures it's a "person" creating the tag (needs maintainer permissions)
  - We could keep doing what we are here, but I think this is a "better" approach
- Don't configure credentials (was only needed because of pushing the tag)
- Explicitly set the target commit to avoid weirdness