### PR TITLE
[SVLS-9100] fix(install): Function App slot workaround + install templates (#455)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Please follow the directions in the referenced document.
 ## Installation:
 Fully stop your web app before installing, modifying, or removing a Datadog APM Site Extension.
 
+## In-repo resources
+
+- [`install-templates/`](install-templates/) — ARM JSON and Bicep templates for installing the extension. Includes a dedicated template for Azure Function Apps with deployment slots, which require extra steps to avoid file-lock failures during install.
+- [`management-scripts/extension/`](management-scripts/extension/) — PowerShell scripts for programmatic install and bulk update. The install script supports `-SlotName` for deployment slot targeting and automatically applies the Function App workaround when needed.
+
 ### IMPORTANT NOTICES:
 #### *Restart* recycles an Application Pool. The app must be *STOPPED* before any changes to this extension.
 #### *Beta users will need to uninstall the beta extension before installing the official release.*

--- a/install-templates/README.md
+++ b/install-templates/README.md
@@ -1,3 +1,13 @@
+## Templates
+
+| File | Scenario |
+|---|---|
+| [`install-web-app.bicep`](install-web-app.bicep) / [`install-web-app.json`](install-web-app.json) | Azure Web App |
+| [`install-web-app-slot.bicep`](install-web-app-slot.bicep) / [`install-web-app-slot.json`](install-web-app-slot.json) | Azure Web App — deployment slot |
+| [`install-function-app-slot.bicep`](install-function-app-slot.bicep) / [`install-function-app-slot.json`](install-function-app-slot.json) | Azure Function App — deployment slot (.NET only) |
+
+Each file has a `version` field (Bicep: top comment; ARM JSON: `metadata.version`). The inline code snippets in the Datadog documentation carry matching version identifiers — if yours differ, re-download the latest template.
+
 ## Configuring Datadog in ARM Templates
 
  - [Parameters to accept Datadog configuration. ](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/parameters)
@@ -67,7 +77,7 @@
         ...
         {
             "type": "Microsoft.Web/sites/siteextensions",
-            "apiVersion": "2021-01-15",
+            "apiVersion": "2025-03-01",
             "name": "[concat(parameters('site_name'), '/Datadog.AzureAppServices.DotNet')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -82,3 +92,31 @@ Pass the relevant parameters to your deployment command:
 ```
 az deployment group create ... --parameters dd_api_key={{api-key}} dd_env={{env}} dd_service={{service}} dd_version={{version}} dd_site={{datadog-intake}}
 ```
+
+## Azure Function Apps (deployment slot)
+
+Function Apps can fail with "MoveDirectory" errors during extension install because the Functions runtime holds file locks on `C:\home\SiteExtensions\`. The fix is `WEBSITE_PRIVATE_EXTENSIONS=0` as a sticky slot setting: it prevents the runtime from loading private site extensions (and acquiring those locks) on the slot, while remaining sticky so it never propagates to production after a swap.
+
+This is only needed when both of the following are true:
+- The target resource is an Azure Function App (kind contains `functionapp`)
+- You are targeting a deployment slot (not the production slot directly)
+
+### ARM JSON
+
+See [`install-function-app-slot.json`](install-function-app-slot.json) for the full template.
+
+Deploy with:
+```
+az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.json
+```
+
+### Bicep
+
+See [`install-function-app-slot.bicep`](install-function-app-slot.bicep) for the full template.
+
+Deploy with:
+```
+az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.bicep
+```
+
+> **Note:** `slotConfigNames` replaces the full list of sticky setting names. If you have other slot-sticky settings, add their names to the `appSettingNames` array.

--- a/install-templates/README.md
+++ b/install-templates/README.md
@@ -105,18 +105,27 @@ This is only needed when both of the following are true:
 
 See [`install-function-app-slot.json`](install-function-app-slot.json) for the full template.
 
+`existingStickyAppSettingNames` is required. It must list every app setting name currently marked slot-sticky on your Function App — the template does a full replace of `slotConfigNames` and any name you omit will be de-stickied. For a brand-new app with no existing sticky settings, pass `[]`.
+
+To get the current list before deploying:
+```
+az rest -m GET --header "Accept=application/json" -u "https://management.azure.com/subscriptions/<SUB>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<APP>/config/slotConfigNames?api-version=2019-08-01" --query "properties.appSettingNames"
+```
+
 Deploy with:
 ```
-az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.json
+az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.json \
+  --parameters existingStickyAppSettingNames='["AzureWebJobsStorage","FUNCTIONS_WORKER_RUNTIME"]'
 ```
 
 ### Bicep
 
 See [`install-function-app-slot.bicep`](install-function-app-slot.bicep) for the full template.
 
+Same requirement as above — provide `existingStickyAppSettingNames` with every currently-sticky setting name, or pass `[]` for a new app.
+
 Deploy with:
 ```
-az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.bicep
+az deployment group create --resource-group <RESOURCE GROUP> --template-file install-function-app-slot.bicep \
+  --parameters existingStickyAppSettingNames='["AzureWebJobsStorage","FUNCTIONS_WORKER_RUNTIME"]'
 ```
-
-> **Note:** `slotConfigNames` replaces the full list of sticky setting names. If you have other slot-sticky settings, add their names to the `appSettingNames` array.

--- a/install-templates/install-function-app-slot.bicep
+++ b/install-templates/install-function-app-slot.bicep
@@ -1,0 +1,60 @@
+// Version: 1.0.0
+// Description: Install Datadog APM extension on an Azure Function App deployment slot. Applies WEBSITE_PRIVATE_EXTENSIONS=0 as a sticky slot setting to prevent MoveDirectory file-lock failures.
+
+@secure()
+param datadogApiKey string
+
+param webAppName string
+param slotName string
+param ddSite string = 'datadoghq.com'
+param ddService string = ''
+@description('Environment tag — set a distinct value for each slot')
+param ddEnv string = 'staging'
+param ddVersion string = ''
+
+resource webApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: webAppName
+}
+
+// WEBSITE_PRIVATE_EXTENSIONS=0 prevents the Functions runtime from holding file locks
+// on C:\home\SiteExtensions\ so Kudu can complete the MoveDirectory step during install.
+// Include all your existing slot app settings in this resource — ARM replaces the full set.
+resource slot 'Microsoft.Web/sites/slots@2025-03-01' = {
+  parent: webApp
+  name: slotName
+  properties: {
+    siteConfig: {
+      appSettings: [
+        // Add your existing slot app settings here (e.g. AzureWebJobsStorage, FUNCTIONS_WORKER_RUNTIME)
+        { name: 'WEBSITE_PRIVATE_EXTENSIONS', value: '0' }
+        { name: 'DD_API_KEY', value: datadogApiKey }
+        { name: 'DD_SITE', value: ddSite }
+        { name: 'DD_SERVICE', value: ddService }
+        { name: 'DD_ENV', value: ddEnv }
+        { name: 'DD_VERSION', value: ddVersion }
+      ]
+    }
+  }
+}
+
+// Marks WEBSITE_PRIVATE_EXTENSIONS as slot-sticky so it survives swaps and never
+// propagates to production. WARNING: replaces the full sticky-settings list —
+// add any other slot-specific setting names to appSettingNames.
+resource stickySettings 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  parent: webApp
+  properties: {
+    appSettingNames: [
+      'WEBSITE_PRIVATE_EXTENSIONS'
+      // Add any other setting names you want to keep slot-specific
+    ]
+  }
+  dependsOn: [slot]
+}
+
+// Only .NET is supported for Azure Function Apps.
+resource datadogExtension 'Microsoft.Web/sites/slots/siteextensions@2025-03-01' = {
+  parent: slot
+  name: 'Datadog.AzureAppServices.DotNet'
+  dependsOn: [stickySettings]
+}

--- a/install-templates/install-function-app-slot.bicep
+++ b/install-templates/install-function-app-slot.bicep
@@ -6,6 +6,9 @@ param datadogApiKey string
 
 param webAppName string
 param slotName string
+
+@description('Names of app settings already marked slot-sticky on this Function App. Pass [] for a new app with no existing sticky settings. This template does a full replace of slotConfigNames — omitting an existing sticky setting name will de-sticky it.')
+param existingStickyAppSettingNames array
 param ddSite string = 'datadoghq.com'
 param ddService string = ''
 @description('Environment tag — set a distinct value for each slot')
@@ -37,17 +40,13 @@ resource slot 'Microsoft.Web/sites/slots@2025-03-01' = {
   }
 }
 
-// Marks WEBSITE_PRIVATE_EXTENSIONS as slot-sticky so it survives swaps and never
-// propagates to production. WARNING: replaces the full sticky-settings list —
-// add any other slot-specific setting names to appSettingNames.
+// Marks WEBSITE_PRIVATE_EXTENSIONS as slot-sticky. Replaces the full slotConfigNames list —
+// existingStickyAppSettingNames must include any settings already marked sticky or they will be de-stickied.
 resource stickySettings 'Microsoft.Web/sites/config@2025-03-01' = {
   name: 'slotConfigNames'
   parent: webApp
   properties: {
-    appSettingNames: [
-      'WEBSITE_PRIVATE_EXTENSIONS'
-      // Add any other setting names you want to keep slot-specific
-    ]
+    appSettingNames: union(existingStickyAppSettingNames, ['WEBSITE_PRIVATE_EXTENSIONS'])
   }
   dependsOn: [slot]
 }

--- a/install-templates/install-function-app-slot.json
+++ b/install-templates/install-function-app-slot.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Install Datadog APM extension on an Azure Function App deployment slot. Applies WEBSITE_PRIVATE_EXTENSIONS=0 as a sticky slot setting to prevent MoveDirectory file-lock failures.",
+    "version": "1.0.0"
+  },
+  "parameters": {
+    "webAppName": {
+      "type": "string",
+      "metadata": { "description": "Name of the Azure Function App" }
+    },
+    "slotName": {
+      "type": "string",
+      "metadata": { "description": "Name of the deployment slot (e.g. staging)" }
+    },
+    "datadogApiKey": {
+      "type": "securestring",
+      "metadata": { "description": "Your Datadog API key" }
+    },
+    "ddSite": {
+      "type": "string",
+      "defaultValue": "datadoghq.com",
+      "metadata": { "description": "Your Datadog site (e.g. datadoghq.com, datadoghq.eu)" }
+    },
+    "ddService": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": { "description": "Service name for unified service tagging" }
+    },
+    "ddEnv": {
+      "type": "string",
+      "defaultValue": "staging",
+      "metadata": { "description": "Environment tag — set a distinct value for each slot" }
+    },
+    "ddVersion": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": { "description": "Version for unified service tagging" }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites/slots/config",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/', parameters('slotName'), '/appsettings')]",
+      "properties": {
+        "WEBSITE_PRIVATE_EXTENSIONS": "0",
+        "DD_API_KEY": "[parameters('datadogApiKey')]",
+        "DD_SITE": "[parameters('ddSite')]",
+        "DD_SERVICE": "[parameters('ddService')]",
+        "DD_ENV": "[parameters('ddEnv')]",
+        "DD_VERSION": "[parameters('ddVersion')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/slotConfigNames')]",
+      "properties": {
+        "appSettingNames": [
+          "WEBSITE_PRIVATE_EXTENSIONS"
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/slots/config', parameters('webAppName'), parameters('slotName'), 'appsettings')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/slots/siteextensions",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/', parameters('slotName'), '/Datadog.AzureAppServices.DotNet')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/config', parameters('webAppName'), 'slotConfigNames')]",
+        "[resourceId('Microsoft.Web/sites/slots/config', parameters('webAppName'), parameters('slotName'), 'appsettings')]"
+      ]
+    }
+  ]
+}

--- a/install-templates/install-function-app-slot.json
+++ b/install-templates/install-function-app-slot.json
@@ -37,6 +37,10 @@
       "type": "string",
       "defaultValue": "",
       "metadata": { "description": "Version for unified service tagging" }
+    },
+    "existingStickyAppSettingNames": {
+      "type": "array",
+      "metadata": { "description": "Names of app settings already marked slot-sticky on this Function App. Pass [] for a new app with no existing sticky settings. This template does a full replace of slotConfigNames — omitting an existing sticky setting name will de-sticky it." }
     }
   },
   "resources": [
@@ -58,9 +62,7 @@
       "apiVersion": "2025-03-01",
       "name": "[concat(parameters('webAppName'), '/slotConfigNames')]",
       "properties": {
-        "appSettingNames": [
-          "WEBSITE_PRIVATE_EXTENSIONS"
-        ]
+        "appSettingNames": "[union(parameters('existingStickyAppSettingNames'), createArray('WEBSITE_PRIVATE_EXTENSIONS'))]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/slots/config', parameters('webAppName'), parameters('slotName'), 'appsettings')]"

--- a/install-templates/install-web-app-slot.bicep
+++ b/install-templates/install-web-app-slot.bicep
@@ -1,0 +1,49 @@
+// Version: 1.0.0
+// Description: Install Datadog APM extension on an Azure Web App deployment slot.
+
+@secure()
+param datadogApiKey string
+
+param webAppName string
+param slotName string
+param ddSite string = 'datadoghq.com'
+param ddService string = 'my-service'
+param ddEnv string = 'staging'
+param ddVersion string = '0.0.0'
+
+@allowed([
+  'Datadog.AzureAppServices.DotNet'
+  'Datadog.AzureAppServices.Java.Apm'
+  'Datadog.AzureAppServices.Node.Apm'
+])
+param extensionName string = 'Datadog.AzureAppServices.DotNet'
+
+resource webApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: webAppName
+}
+
+resource slot 'Microsoft.Web/sites/slots@2025-03-01' = {
+  parent: webApp
+  name: slotName
+  properties: {
+    siteConfig: {
+      appSettings: [
+        // Add your existing slot app settings here
+        { name: 'DD_API_KEY', value: datadogApiKey }
+        { name: 'DD_SITE', value: ddSite }
+        { name: 'DD_SERVICE', value: ddService }
+        { name: 'DD_ENV', value: ddEnv }
+        { name: 'DD_VERSION', value: ddVersion }
+      ]
+    }
+  }
+}
+
+resource datadogExtension 'Microsoft.Web/sites/slots/siteextensions@2025-03-01' = {
+  parent: slot
+  name: extensionName
+  // Available values for extensionName:
+  // 'Datadog.AzureAppServices.DotNet'
+  // 'Datadog.AzureAppServices.Java.Apm'
+  // 'Datadog.AzureAppServices.Node.Apm'
+}

--- a/install-templates/install-web-app-slot.bicep
+++ b/install-templates/install-web-app-slot.bicep
@@ -7,9 +7,9 @@ param datadogApiKey string
 param webAppName string
 param slotName string
 param ddSite string = 'datadoghq.com'
-param ddService string = 'my-service'
+param ddService string = ''
 param ddEnv string = 'staging'
-param ddVersion string = '0.0.0'
+param ddVersion string = ''
 
 @allowed([
   'Datadog.AzureAppServices.DotNet'

--- a/install-templates/install-web-app-slot.json
+++ b/install-templates/install-web-app-slot.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Install Datadog APM extension on an Azure Web App deployment slot.",
+    "version": "1.0.0"
+  },
+  "parameters": {
+    "webAppName": {
+      "type": "string",
+      "metadata": { "description": "Name of the Azure Web App" }
+    },
+    "slotName": {
+      "type": "string",
+      "metadata": { "description": "Name of the deployment slot (e.g. staging)" }
+    },
+    "datadogApiKey": {
+      "type": "securestring",
+      "metadata": { "description": "Your Datadog API key" }
+    },
+    "ddSite": {
+      "type": "string",
+      "defaultValue": "datadoghq.com",
+      "metadata": { "description": "Your Datadog site" }
+    },
+    "ddService": {
+      "type": "string",
+      "defaultValue": "my-service",
+      "metadata": { "description": "Service name for unified service tagging" }
+    },
+    "ddEnv": {
+      "type": "string",
+      "defaultValue": "staging",
+      "metadata": { "description": "Environment tag — set a distinct value for each slot" }
+    },
+    "ddVersion": {
+      "type": "string",
+      "defaultValue": "0.0.0",
+      "metadata": { "description": "Version for unified service tagging" }
+    },
+    "extensionName": {
+      "type": "string",
+      "defaultValue": "Datadog.AzureAppServices.DotNet",
+      "allowedValues": [
+        "Datadog.AzureAppServices.DotNet",
+        "Datadog.AzureAppServices.Java.Apm",
+        "Datadog.AzureAppServices.Node.Apm"
+      ],
+      "metadata": { "description": "Datadog extension name for your runtime" }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites/slots",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/', parameters('slotName'))]",
+      "properties": {
+        "siteConfig": {
+          "appSettings": [
+            { "name": "DD_API_KEY", "value": "[parameters('datadogApiKey')]" },
+            { "name": "DD_SITE", "value": "[parameters('ddSite')]" },
+            { "name": "DD_SERVICE", "value": "[parameters('ddService')]" },
+            { "name": "DD_ENV", "value": "[parameters('ddEnv')]" },
+            { "name": "DD_VERSION", "value": "[parameters('ddVersion')]" }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/slots/siteextensions",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/', parameters('slotName'), '/', parameters('extensionName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/slots', parameters('webAppName'), parameters('slotName'))]"
+      ]
+    }
+  ]
+}

--- a/install-templates/install-web-app-slot.json
+++ b/install-templates/install-web-app-slot.json
@@ -25,7 +25,7 @@
     },
     "ddService": {
       "type": "string",
-      "defaultValue": "my-service",
+      "defaultValue": "",
       "metadata": { "description": "Service name for unified service tagging" }
     },
     "ddEnv": {
@@ -35,7 +35,7 @@
     },
     "ddVersion": {
       "type": "string",
-      "defaultValue": "0.0.0",
+      "defaultValue": "",
       "metadata": { "description": "Version for unified service tagging" }
     },
     "extensionName": {

--- a/install-templates/install-web-app.bicep
+++ b/install-templates/install-web-app.bicep
@@ -1,0 +1,45 @@
+// Version: 1.0.0
+// Description: Install Datadog APM extension on an Azure Web App.
+
+@secure()
+param datadogApiKey string
+
+param webAppName string
+param ddSite string = 'datadoghq.com'
+param ddService string = 'my-service'
+param ddEnv string = 'prod'
+param ddVersion string = '0.0.0'
+
+@allowed([
+  'Datadog.AzureAppServices.DotNet'
+  'Datadog.AzureAppServices.Java.Apm'
+  'Datadog.AzureAppServices.Node.Apm'
+])
+param extensionName string = 'Datadog.AzureAppServices.DotNet'
+
+resource webApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: webAppName
+}
+
+resource appSettings 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'appsettings'
+  parent: webApp
+  properties: {
+    // Add your existing app settings here
+    DD_API_KEY: datadogApiKey
+    DD_SITE: ddSite
+    DD_SERVICE: ddService
+    DD_ENV: ddEnv
+    DD_VERSION: ddVersion
+  }
+}
+
+resource datadogExtension 'Microsoft.Web/sites/siteextensions@2025-03-01' = {
+  parent: webApp
+  name: extensionName
+  // Available values for extensionName:
+  // 'Datadog.AzureAppServices.DotNet'
+  // 'Datadog.AzureAppServices.Java.Apm'
+  // 'Datadog.AzureAppServices.Node.Apm'
+  dependsOn: [appSettings]
+}

--- a/install-templates/install-web-app.bicep
+++ b/install-templates/install-web-app.bicep
@@ -6,9 +6,9 @@ param datadogApiKey string
 
 param webAppName string
 param ddSite string = 'datadoghq.com'
-param ddService string = 'my-service'
+param ddService string = ''
 param ddEnv string = 'prod'
-param ddVersion string = '0.0.0'
+param ddVersion string = ''
 
 @allowed([
   'Datadog.AzureAppServices.DotNet'

--- a/install-templates/install-web-app.json
+++ b/install-templates/install-web-app.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Install Datadog APM extension on an Azure Web App.",
+    "version": "1.0.0"
+  },
+  "parameters": {
+    "webAppName": {
+      "type": "string",
+      "metadata": { "description": "Name of the Azure Web App" }
+    },
+    "datadogApiKey": {
+      "type": "securestring",
+      "metadata": { "description": "Your Datadog API key" }
+    },
+    "ddSite": {
+      "type": "string",
+      "defaultValue": "datadoghq.com",
+      "metadata": { "description": "Your Datadog site (e.g. datadoghq.com, datadoghq.eu)" }
+    },
+    "ddService": {
+      "type": "string",
+      "defaultValue": "my-service",
+      "metadata": { "description": "Service name for unified service tagging" }
+    },
+    "ddEnv": {
+      "type": "string",
+      "defaultValue": "prod",
+      "metadata": { "description": "Environment name for unified service tagging" }
+    },
+    "ddVersion": {
+      "type": "string",
+      "defaultValue": "0.0.0",
+      "metadata": { "description": "Version for unified service tagging" }
+    },
+    "extensionName": {
+      "type": "string",
+      "defaultValue": "Datadog.AzureAppServices.DotNet",
+      "allowedValues": [
+        "Datadog.AzureAppServices.DotNet",
+        "Datadog.AzureAppServices.Java.Apm",
+        "Datadog.AzureAppServices.Node.Apm"
+      ],
+      "metadata": { "description": "Datadog extension name for your runtime" }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/appsettings')]",
+      "properties": {
+        "DD_API_KEY": "[parameters('datadogApiKey')]",
+        "DD_SITE": "[parameters('ddSite')]",
+        "DD_SERVICE": "[parameters('ddService')]",
+        "DD_ENV": "[parameters('ddEnv')]",
+        "DD_VERSION": "[parameters('ddVersion')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/siteextensions",
+      "apiVersion": "2025-03-01",
+      "name": "[concat(parameters('webAppName'), '/', parameters('extensionName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/config', parameters('webAppName'), 'appsettings')]"
+      ]
+    }
+  ]
+}

--- a/install-templates/install-web-app.json
+++ b/install-templates/install-web-app.json
@@ -21,7 +21,7 @@
     },
     "ddService": {
       "type": "string",
-      "defaultValue": "my-service",
+      "defaultValue": "",
       "metadata": { "description": "Service name for unified service tagging" }
     },
     "ddEnv": {
@@ -31,7 +31,7 @@
     },
     "ddVersion": {
       "type": "string",
-      "defaultValue": "0.0.0",
+      "defaultValue": "",
       "metadata": { "description": "Version for unified service tagging" }
     },
     "extensionName": {

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -42,7 +42,7 @@
 
 # Example call targeting a deployment slot on a Function App:
 #
-# .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $webAppName -SlotName staging -DDApiKey $ddApiKey -DDSite $ddSite
+# .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $functionAppName -SlotName staging -DDApiKey $ddApiKey -DDSite $ddSite
 #
 
 if ($Username -eq "ambient") {
@@ -67,11 +67,11 @@ $targetApiUrl = if ($SlotName) { "${siteApiUrl}/slots/${SlotName}" } else { $sit
 
 $displayName = if ($SlotName) { "${SiteName}/${SlotName}" } else { $SiteName }
 
-if ($SlotName) {
-    $slotConfig = az rest -m GET --header "Accept=application/json" -u "${targetApiUrl}?api-version=2019-08-01" | ConvertFrom-Json
-    $baseApiUrl = "https://$($slotConfig.properties.enabledHostNames -like "*.scm.*")/api"
+$mainScmHost = $siteConfig.properties.enabledHostNames -like "*.scm.*"
+$baseApiUrl = if ($SlotName) {
+    "https://$($mainScmHost -replace '\.scm\.', "-${SlotName}.scm.")/api"
 } else {
-    $baseApiUrl = "https://$($siteConfig.properties.enabledHostNames -like "*.scm.*")/api"
+    "https://${mainScmHost}/api"
 }
 
 $siteExtensionsBase="${baseApiUrl}/siteextensions"

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -77,7 +77,7 @@ $displayName = if ($SlotName)
 { $SiteName
 }
 
-$mainScmHost = $siteConfig.properties.enabledHostNames -like "*.scm.*"
+$mainScmHost = ($siteConfig.properties.enabledHostNames -like "*.scm.*")[0]
 $baseApiUrl = if ($SlotName)
 {
     "https://$($mainScmHost -replace '\.scm\.', "-${SlotName}.scm.")/api"

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -1,3 +1,6 @@
+# Version: 2.0.0
+# Changelog: Added -SlotName support and automatic WEBSITE_PRIVATE_EXTENSIONS=0 sticky
+#             slot setting for Azure Function Apps to prevent MoveDirectory install failures.
 
 # Per site, you can use the username and password from the publish profile you download.
 # The recommended approach is to use a service account which has permission to access Kudu
@@ -6,6 +9,7 @@
     [Parameter(Mandatory=$true)][string]$SubscriptionId,
     [Parameter(Mandatory=$true)][string]$ResourceGroup,
     [Parameter(Mandatory=$true)][string]$SiteName,
+    [Parameter(Mandatory=$false)][string]$SlotName,
     [Parameter(Mandatory=$false)][string]$Username="ambient",
     [Parameter(Mandatory=$false)][string]$Password="ambient",
     [Parameter(Mandatory=$false)][string]$Extension="Datadog.AzureAppServices.DotNet",
@@ -18,7 +22,7 @@
     [Parameter(Mandatory=$false)][Switch]$Remove
  )
 
-# 
+#
 # Example calls of this script:
 #
 # .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $webAppName -Username $username -Password $password
@@ -29,11 +33,16 @@
 # .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $webAppName -Remove
 #
 # .\install-latest-extension.ps1 -SubscriptionId 8c56d827-5f07-45ce-8f2b-6c5001db5c6f -ResourceGroup apm-aas-junkyard -SiteName dd-netcore31-junkyard-dev -Extension DevelopmentVerification.DdDotNet.Apm -ExtensionVersion 0.1.37-prerelease
-# 
+#
 
 # Example call of install with datadog environment variables applied:
-# 
+#
 # .\install-latest-extension.ps1 -Username $username -Password $password -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $webAppName -DDSite $ddSite -DDApiKey $ddApiKey -DDEnv $ddEnv -DDService $ddService -DDVersion $ddVersion
+#
+
+# Example call targeting a deployment slot on a Function App:
+#
+# .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $webAppName -SlotName staging -DDApiKey $ddApiKey -DDSite $ddSite
 #
 
 if ($Username -eq "ambient") {
@@ -52,97 +61,144 @@ $userAgent = "powershell/1.0"
 $siteApiUrl="https://management.azure.com/subscriptions/${SubscriptionId}/resourceGroups/${ResourceGroup}/providers/Microsoft.Web/sites/${SiteName}"
 $siteConfig = az rest -m GET --header "Accept=application/json" -u "${siteApiUrl}?api-version=2019-08-01" | ConvertFrom-Json
 
-$baseApiUrl = "https://$($siteConfig.properties.enabledHostNames -like "*.scm.*")/api"
+$kind = $siteConfig.kind
+
+$targetApiUrl = if ($SlotName) { "${siteApiUrl}/slots/${SlotName}" } else { $siteApiUrl }
+
+$displayName = if ($SlotName) { "${SiteName}/${SlotName}" } else { $SiteName }
+
+if ($SlotName) {
+    $slotConfig = az rest -m GET --header "Accept=application/json" -u "${targetApiUrl}?api-version=2019-08-01" | ConvertFrom-Json
+    $baseApiUrl = "https://$($slotConfig.properties.enabledHostNames -like "*.scm.*")/api"
+} else {
+    $baseApiUrl = "https://$($siteConfig.properties.enabledHostNames -like "*.scm.*")/api"
+}
+
 $siteExtensionsBase="${baseApiUrl}/siteextensions"
 $siteExtensionManage="${baseApiUrl}/siteextensions/${Extension}"
 
+# Function App file-lock workaround: set WEBSITE_PRIVATE_EXTENSIONS=0 as a sticky slot
+# setting so the Functions runtime does not hold file handles on C:\home\SiteExtensions\
+# during the Kudu MoveDirectory step. Only applies to Function App + slot deployments.
+# See: https://github.com/DataDog/datadog-aas-extension/issues/455
+if ($SlotName -and $kind -like '*functionapp*') {
+    Write-Output "[${SiteName}/${SlotName}] Function App detected — applying WEBSITE_PRIVATE_EXTENSIONS=0 as sticky slot setting to prevent install failures."
+    az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --settings "WEBSITE_PRIVATE_EXTENSIONS=0"
+    az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --slot-settings "WEBSITE_PRIVATE_EXTENSIONS=0"
+    Write-Output "[${SiteName}/${SlotName}] Sticky setting applied. Proceeding with stop/install/start."
+}
+
 # Stop the web app
 # https://docs.microsoft.com/en-us/rest/api/appservice/webapps/stop
-Write-Output "[${SiteName}] Stopping webapp"
-az rest -m POST --header "Accept=application/json" -u "${siteApiUrl}/stop?api-version=2019-08-01"
+Write-Output "[${displayName}] Stopping webapp"
+az rest -m POST --header "Accept=application/json" -u "${targetApiUrl}/stop?api-version=2019-08-01"
 
 $skipVar="<not-set>"
 
-az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_AAS_SCRIPT_INSTALL=1
-	
-if ($DDApiKey -ne $skipVar) {
-	az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_API_KEY=$DDApiKey
+if ($SlotName) {
+    az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_AAS_SCRIPT_INSTALL=1
+} else {
+    az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_AAS_SCRIPT_INSTALL=1
 }
-	
+
+if ($DDApiKey -ne $skipVar) {
+    if ($SlotName) {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_API_KEY=$DDApiKey
+    } else {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_API_KEY=$DDApiKey
+    }
+}
+
 if ($DDSite -ne $skipVar) {
-	az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SITE=$DDSite
+    if ($SlotName) {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_SITE=$DDSite
+    } else {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SITE=$DDSite
+    }
 }
 
 if ($DDEnv -ne $skipVar) {
-	az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_ENV=$DDEnv
+    if ($SlotName) {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_ENV=$DDEnv
+    } else {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_ENV=$DDEnv
+    }
 }
 
 if ($DDService -ne $skipVar) {
-	az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SERVICE=$DDService
+    if ($SlotName) {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_SERVICE=$DDService
+    } else {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SERVICE=$DDService
+    }
 }
 
 if ($DDVersion -ne $skipVar) {
-	az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_VERSION=$DDVersion
+    if ($SlotName) {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_VERSION=$DDVersion
+    } else {
+        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_VERSION=$DDVersion
+    }
 }
 
 if ($Remove) {
-  Write-Output "[${SiteName}] Attempting to remove ${Extension}"
+  Write-Output "[${displayName}] Attempting to remove ${Extension}"
   Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
-  Write-Output "[${SiteName}] Completed request to remove ${Extension}"
+  Write-Output "[${displayName}] Completed request to remove ${Extension}"
 }
 else {
 	if ($PSBoundParameters.ContainsKey('ExtensionVersion')) {
-		
-        Write-Output "[${SiteName}] Attempting to install version ${ExtensionVersion} of ${Extension}"
-		
+
+        Write-Output "[${displayName}] Attempting to install version ${ExtensionVersion} of ${Extension}"
+
 		$packageUrl="https://globalcdn.nuget.org/packages/${Extension}.${ExtensionVersion}.nupkg".ToLower()
-		
-		Write-Output "[${SiteName}] Setting package URL to ${packageUrl}"
-		
+
+		Write-Output "[${displayName}] Setting package URL to ${packageUrl}"
+
 		$install=$true
-		
+
 		# If this is a downgrade, we need to remove the extension first or the install logic will ignore the package
 		$installedExtensions=Invoke-RestMethod -Uri $siteExtensionsBase -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
-		
+
 		Foreach ($installedExtension in @($installedExtensions)){
-			
+
 			if ($installedExtension.id -eq $Extension) {
 				if ($installedExtension.version -eq $ExtensionVersion) {
-					Write-Output "[${SiteName}] Package version (${ExtensionVersion}) is already installed."
+					Write-Output "[${displayName}] Package version (${ExtensionVersion}) is already installed."
 					$install=$false
 					break;
 				}
 				else {
 					Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
-					Write-Output "[${SiteName}] Requested package removal. "
-					Write-Output "[${SiteName}] Waiting ten seconds to ensure removal is complete. "
+					Write-Output "[${displayName}] Requested package removal. "
+					Write-Output "[${displayName}] Waiting ten seconds to ensure removal is complete. "
 					Start-Sleep -s 10
 					break;
 				}
 			}
 		}
-		
+
 		if ($install) {
 			# https://github.com/projectkudu/kudu/blob/98ad238b860f81a4cb4e3419c8785a58ba68e661/Kudu.Services/SiteExtensions/SiteExtensionController.cs#L240
-			$siteExtensionInfo = @{        
+			$siteExtensionInfo = @{
 			  packageUri = $packageUrl
 			};
-			
+
 			$json = $siteExtensionInfo | ConvertTo-Json;
-			
+
 			Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT -ContentType application/json -Body $json
-			
-			Write-Output "[${SiteName}] Completed request to install version ${ExtensionVersion} of ${Extension}"
+
+			Write-Output "[${displayName}] Completed request to install version ${ExtensionVersion} of ${Extension}"
 		}
 	}
 	else {
         Write-Output "Attempting to install latest ${Extension}"
         Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
-		Write-Output "[${SiteName}] Completed request to install latest of ${Extension}"
+		Write-Output "[${displayName}] Completed request to install latest of ${Extension}"
 	}
 }
 
 # Start the web app
 # https://docs.microsoft.com/en-us/rest/api/appservice/webapps/start
-Write-Output "[${SiteName}] Starting webapp"
-az rest -m POST --header "Accept=application/json" -u "${siteApiUrl}/start?api-version=2019-08-01"
+Write-Output "[${displayName}] Starting webapp"
+az rest -m POST --header "Accept=application/json" -u "${targetApiUrl}/start?api-version=2019-08-01"

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -93,53 +93,20 @@ if ($SlotName -and $kind -like '*functionapp*') {
     Write-Output "[${SiteName}/${SlotName}] Sticky setting applied."
 }
 
-$skipVar="<not-set>"
+$skipVar = "<not-set>"
 
-if ($SlotName) {
-    az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_AAS_SCRIPT_INSTALL=1
-} else {
-    az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_AAS_SCRIPT_INSTALL=1
+function Set-AppSetting($settingName, $value) {
+    $cmdArgs = @('-n', $SiteName, '-g', $ResourceGroup, '--settings', "$settingName=$value")
+    if ($SlotName) { $cmdArgs += @('--slot', $SlotName) }
+    az webapp config appsettings set @cmdArgs
 }
 
-if ($DDApiKey -ne $skipVar) {
-    if ($SlotName) {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_API_KEY=$DDApiKey
-    } else {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_API_KEY=$DDApiKey
-    }
-}
-
-if ($DDSite -ne $skipVar) {
-    if ($SlotName) {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_SITE=$DDSite
-    } else {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SITE=$DDSite
-    }
-}
-
-if ($DDEnv -ne $skipVar) {
-    if ($SlotName) {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_ENV=$DDEnv
-    } else {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_ENV=$DDEnv
-    }
-}
-
-if ($DDService -ne $skipVar) {
-    if ($SlotName) {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_SERVICE=$DDService
-    } else {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_SERVICE=$DDService
-    }
-}
-
-if ($DDVersion -ne $skipVar) {
-    if ($SlotName) {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --slot $SlotName --settings DD_VERSION=$DDVersion
-    } else {
-        az webapp config appsettings set -n ${SiteName} -g ${ResourceGroup} --settings DD_VERSION=$DDVersion
-    }
-}
+Set-AppSetting 'DD_AAS_SCRIPT_INSTALL' '1'
+if ($DDApiKey  -ne $skipVar) { Set-AppSetting 'DD_API_KEY' $DDApiKey }
+if ($DDSite    -ne $skipVar) { Set-AppSetting 'DD_SITE'    $DDSite }
+if ($DDEnv     -ne $skipVar) { Set-AppSetting 'DD_ENV'     $DDEnv }
+if ($DDService -ne $skipVar) { Set-AppSetting 'DD_SERVICE' $DDService }
+if ($DDVersion -ne $skipVar) { Set-AppSetting 'DD_VERSION' $DDVersion }
 
 if ($Remove) {
   Write-Output "[${displayName}] Attempting to remove ${Extension}"

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -83,7 +83,6 @@ $siteExtensionManage="${baseApiUrl}/siteextensions/${Extension}"
 # See: https://github.com/DataDog/datadog-aas-extension/issues/455
 if ($SlotName -and $kind -like '*functionapp*') {
     Write-Output "[${SiteName}/${SlotName}] Function App detected — applying WEBSITE_PRIVATE_EXTENSIONS=0 as sticky slot setting to prevent install failures."
-    az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --settings "WEBSITE_PRIVATE_EXTENSIONS=0"
     az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --slot-settings "WEBSITE_PRIVATE_EXTENSIONS=0"
     Write-Output "[${SiteName}/${SlotName}] Sticky setting applied. Proceeding with stop/install/start."
 }

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -5,7 +5,7 @@
 # Per site, you can use the username and password from the publish profile you download.
 # The recommended approach is to use a service account which has permission to access Kudu
 # Note that the $username here should look like `SomeUserName`, and **not** `SomeSite\SomeUserName`
- param (
+param (
     [Parameter(Mandatory=$true)][string]$SubscriptionId,
     [Parameter(Mandatory=$true)][string]$ResourceGroup,
     [Parameter(Mandatory=$true)][string]$SiteName,
@@ -20,7 +20,7 @@
     [Parameter(Mandatory=$false)][string]$DDVersion="<not-set>",
     [Parameter(Mandatory=$false)][string]$ExtensionVersion,
     [Parameter(Mandatory=$false)][Switch]$Remove
- )
+)
 
 #
 # Example calls of this script:
@@ -45,12 +45,14 @@
 # .\install-latest-extension.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -SiteName $functionAppName -SlotName staging -DDApiKey $ddApiKey -DDSite $ddSite
 #
 
-if ($Username -eq "ambient") {
-	$Username=$env:DD_AAS_USER
+if ($Username -eq "ambient")
+{
+    $Username=$env:DD_AAS_USER
 }
 
-if ($Password -eq "ambient") {
-	$Password=$env:DD_AAS_PASS
+if ($Password -eq "ambient")
+{
+    $Password=$env:DD_AAS_PASS
 }
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -63,14 +65,24 @@ $siteConfig = az rest -m GET --header "Accept=application/json" -u "${siteApiUrl
 
 $kind = $siteConfig.kind
 
-$targetApiUrl = if ($SlotName) { "${siteApiUrl}/slots/${SlotName}" } else { $siteApiUrl }
+$targetApiUrl = if ($SlotName)
+{ "${siteApiUrl}/slots/${SlotName}"
+} else
+{ $siteApiUrl
+}
 
-$displayName = if ($SlotName) { "${SiteName}/${SlotName}" } else { $SiteName }
+$displayName = if ($SlotName)
+{ "${SiteName}/${SlotName}"
+} else
+{ $SiteName
+}
 
 $mainScmHost = $siteConfig.properties.enabledHostNames -like "*.scm.*"
-$baseApiUrl = if ($SlotName) {
+$baseApiUrl = if ($SlotName)
+{
     "https://$($mainScmHost -replace '\.scm\.', "-${SlotName}.scm.")/api"
-} else {
+} else
+{
     "https://${mainScmHost}/api"
 }
 
@@ -86,83 +98,103 @@ az rest -m POST --header "Accept=application/json" -u "${targetApiUrl}/stop?api-
 # setting so the Functions runtime does not hold file handles on C:\home\SiteExtensions\
 # during the Kudu MoveDirectory step. Applied after stop so no recycle is triggered —
 # the setting takes effect on the subsequent start. Only applies to Function App + slot deployments.
-# See: https://github.com/DataDog/datadog-aas-extension/issues/455
-if ($SlotName -and $kind -like '*functionapp*') {
+# slot-settings here not to be confused with settings block afterwards.
+if ($SlotName -and $kind -like '*functionapp*')
+{
     Write-Output "[${SiteName}/${SlotName}] Function App detected — applying WEBSITE_PRIVATE_EXTENSIONS=0 as sticky slot setting to prevent install failures."
     az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --slot-settings "WEBSITE_PRIVATE_EXTENSIONS=0"
     Write-Output "[${SiteName}/${SlotName}] Sticky setting applied."
 }
 
-$skipVar = "<not-set>"
+$skipVar   = "<not-set>"
 
-function Set-AppSetting($settingName, $value) {
-    $cmdArgs = @('-n', $SiteName, '-g', $ResourceGroup, '--settings', "$settingName=$value")
-    if ($SlotName) { $cmdArgs += @('--slot', $SlotName) }
+function Set-AppSetting($name, $value)
+{
+    $cmdArgs = @('-n', $SiteName, '-g', $ResourceGroup, '--settings', "$name=$value")
+    if ($SlotName)
+    { $cmdArgs += @('--slot', $SlotName)
+    }
     az webapp config appsettings set @cmdArgs
 }
 
 Set-AppSetting 'DD_AAS_SCRIPT_INSTALL' '1'
-if ($DDApiKey  -ne $skipVar) { Set-AppSetting 'DD_API_KEY' $DDApiKey }
-if ($DDSite    -ne $skipVar) { Set-AppSetting 'DD_SITE'    $DDSite }
-if ($DDEnv     -ne $skipVar) { Set-AppSetting 'DD_ENV'     $DDEnv }
-if ($DDService -ne $skipVar) { Set-AppSetting 'DD_SERVICE' $DDService }
-if ($DDVersion -ne $skipVar) { Set-AppSetting 'DD_VERSION' $DDVersion }
-
-if ($Remove) {
-  Write-Output "[${displayName}] Attempting to remove ${Extension}"
-  Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
-  Write-Output "[${displayName}] Completed request to remove ${Extension}"
+if ($DDApiKey  -ne $skipVar)
+{ Set-AppSetting 'DD_API_KEY' $DDApiKey
 }
-else {
-	if ($PSBoundParameters.ContainsKey('ExtensionVersion')) {
+if ($DDSite    -ne $skipVar)
+{ Set-AppSetting 'DD_SITE'    $DDSite
+}
+if ($DDEnv     -ne $skipVar)
+{ Set-AppSetting 'DD_ENV'     $DDEnv
+}
+if ($DDService -ne $skipVar)
+{ Set-AppSetting 'DD_SERVICE' $DDService
+}
+if ($DDVersion -ne $skipVar)
+{ Set-AppSetting 'DD_VERSION' $DDVersion
+}
+
+if ($Remove)
+{
+    Write-Output "[${displayName}] Attempting to remove ${Extension}"
+    Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
+    Write-Output "[${displayName}] Completed request to remove ${Extension}"
+} else
+{
+    if ($PSBoundParameters.ContainsKey('ExtensionVersion'))
+    {
 
         Write-Output "[${displayName}] Attempting to install version ${ExtensionVersion} of ${Extension}"
 
-		$packageUrl="https://globalcdn.nuget.org/packages/${Extension}.${ExtensionVersion}.nupkg".ToLower()
+        $packageUrl="https://globalcdn.nuget.org/packages/${Extension}.${ExtensionVersion}.nupkg".ToLower()
 
-		Write-Output "[${displayName}] Setting package URL to ${packageUrl}"
+        Write-Output "[${displayName}] Setting package URL to ${packageUrl}"
 
-		$install=$true
+        $install=$true
 
-		# If this is a downgrade, we need to remove the extension first or the install logic will ignore the package
-		$installedExtensions=Invoke-RestMethod -Uri $siteExtensionsBase -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
+        # If this is a downgrade, we need to remove the extension first or the install logic will ignore the package
+        $installedExtensions=Invoke-RestMethod -Uri $siteExtensionsBase -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
 
-		Foreach ($installedExtension in @($installedExtensions)){
+        Foreach ($installedExtension in @($installedExtensions))
+        {
 
-			if ($installedExtension.id -eq $Extension) {
-				if ($installedExtension.version -eq $ExtensionVersion) {
-					Write-Output "[${displayName}] Package version (${ExtensionVersion}) is already installed."
-					$install=$false
-					break;
-				}
-				else {
-					Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
-					Write-Output "[${displayName}] Requested package removal. "
-					Write-Output "[${displayName}] Waiting ten seconds to ensure removal is complete. "
-					Start-Sleep -s 10
-					break;
-				}
-			}
-		}
+            if ($installedExtension.id -eq $Extension)
+            {
+                if ($installedExtension.version -eq $ExtensionVersion)
+                {
+                    Write-Output "[${displayName}] Package version (${ExtensionVersion}) is already installed."
+                    $install=$false
+                    break;
+                } else
+                {
+                    Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method DELETE
+                    Write-Output "[${displayName}] Requested package removal. "
+                    Write-Output "[${displayName}] Waiting ten seconds to ensure removal is complete. "
+                    Start-Sleep -s 10
+                    break;
+                }
+            }
+        }
 
-		if ($install) {
-			# https://github.com/projectkudu/kudu/blob/98ad238b860f81a4cb4e3419c8785a58ba68e661/Kudu.Services/SiteExtensions/SiteExtensionController.cs#L240
-			$siteExtensionInfo = @{
-			  packageUri = $packageUrl
-			};
+        if ($install)
+        {
+            # https://github.com/projectkudu/kudu/blob/98ad238b860f81a4cb4e3419c8785a58ba68e661/Kudu.Services/SiteExtensions/SiteExtensionController.cs#L240
+            $siteExtensionInfo = @{
+                packageUri = $packageUrl
+            };
 
-			$json = $siteExtensionInfo | ConvertTo-Json;
+            $json = $siteExtensionInfo | ConvertTo-Json;
 
-			Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT -ContentType application/json -Body $json
+            Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT -ContentType application/json -Body $json
 
-			Write-Output "[${displayName}] Completed request to install version ${ExtensionVersion} of ${Extension}"
-		}
-	}
-	else {
+            Write-Output "[${displayName}] Completed request to install version ${ExtensionVersion} of ${Extension}"
+        }
+    } else
+    {
         Write-Output "Attempting to install latest ${Extension}"
         Invoke-RestMethod -Uri $siteExtensionManage -Headers @{Authorization=$("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method PUT
-		Write-Output "[${displayName}] Completed request to install latest of ${Extension}"
-	}
+        Write-Output "[${displayName}] Completed request to install latest of ${Extension}"
+    }
 }
 
 # Start the web app

--- a/management-scripts/extension/install-latest-extension.ps1
+++ b/management-scripts/extension/install-latest-extension.ps1
@@ -77,20 +77,21 @@ $baseApiUrl = if ($SlotName) {
 $siteExtensionsBase="${baseApiUrl}/siteextensions"
 $siteExtensionManage="${baseApiUrl}/siteextensions/${Extension}"
 
-# Function App file-lock workaround: set WEBSITE_PRIVATE_EXTENSIONS=0 as a sticky slot
-# setting so the Functions runtime does not hold file handles on C:\home\SiteExtensions\
-# during the Kudu MoveDirectory step. Only applies to Function App + slot deployments.
-# See: https://github.com/DataDog/datadog-aas-extension/issues/455
-if ($SlotName -and $kind -like '*functionapp*') {
-    Write-Output "[${SiteName}/${SlotName}] Function App detected — applying WEBSITE_PRIVATE_EXTENSIONS=0 as sticky slot setting to prevent install failures."
-    az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --slot-settings "WEBSITE_PRIVATE_EXTENSIONS=0"
-    Write-Output "[${SiteName}/${SlotName}] Sticky setting applied. Proceeding with stop/install/start."
-}
-
 # Stop the web app
 # https://docs.microsoft.com/en-us/rest/api/appservice/webapps/stop
 Write-Output "[${displayName}] Stopping webapp"
 az rest -m POST --header "Accept=application/json" -u "${targetApiUrl}/stop?api-version=2019-08-01"
+
+# Function App file-lock workaround: set WEBSITE_PRIVATE_EXTENSIONS=0 as a sticky slot
+# setting so the Functions runtime does not hold file handles on C:\home\SiteExtensions\
+# during the Kudu MoveDirectory step. Applied after stop so no recycle is triggered —
+# the setting takes effect on the subsequent start. Only applies to Function App + slot deployments.
+# See: https://github.com/DataDog/datadog-aas-extension/issues/455
+if ($SlotName -and $kind -like '*functionapp*') {
+    Write-Output "[${SiteName}/${SlotName}] Function App detected — applying WEBSITE_PRIVATE_EXTENSIONS=0 as sticky slot setting to prevent install failures."
+    az webapp config appsettings set -n $SiteName -g $ResourceGroup --slot $SlotName --slot-settings "WEBSITE_PRIVATE_EXTENSIONS=0"
+    Write-Output "[${SiteName}/${SlotName}] Sticky setting applied."
+}
 
 $skipVar="<not-set>"
 

--- a/management-scripts/extension/update-all-site-extensions.ps1
+++ b/management-scripts/extension/update-all-site-extensions.ps1
@@ -111,7 +111,13 @@ Foreach($webapp in @($allSites)) {
 					$hasSlotExtension = $true
 					$extensionUpdate = "$PSScriptRoot\install-latest-extension.ps1 -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -SiteName $siteName -SlotName $slotName -Username $Username -Password $Password -Extension $Extension"
 					if ($Remove) { $extensionUpdate = "${extensionUpdate} -Remove" }
-					elseif ($requiresSpecificVersion) { $extensionUpdate = "${extensionUpdate} -ExtensionVersion ${ExtensionVersion}" }
+					elseif ($requiresSpecificVersion) {
+						if ($installedExtension.version -eq $ExtensionVersion) {
+							Write-Output "[${siteName}/${slotName}] Version (${extVersion}) of ${Extension} already installed."
+							break
+						}
+						else { $extensionUpdate = "${extensionUpdate} -ExtensionVersion ${ExtensionVersion}" }
+					}
 					elseif ($installedExtension.local_is_latest_version) {
 						Write-Output "[${siteName}/${slotName}] Latest version already installed."
 						break

--- a/management-scripts/extension/update-all-site-extensions.ps1
+++ b/management-scripts/extension/update-all-site-extensions.ps1
@@ -1,3 +1,5 @@
+# Version: 2.0.0
+# Changelog: Added -IncludeSlots flag to enumerate and update deployment slots.
 
 # Per site, you can use the username and password from the publish profile you download.
 # The recommended approach is to use a service account which has permission to access Kudu
@@ -9,18 +11,22 @@
     [Parameter(Mandatory=$false)][string]$Password="ambient",
     [Parameter(Mandatory=$false)][string]$Extension="Datadog.AzureAppServices.DotNet",
     [Parameter(Mandatory=$false)][string]$ExtensionVersion,
-    [Parameter(Mandatory=$false)][Switch]$Remove
+    [Parameter(Mandatory=$false)][Switch]$Remove,
+    [Parameter(Mandatory=$false)][Switch]$IncludeSlots
  )
 
-# 
+#
 # Example call of this script to update all installed extensions in a resource group:
 # .\update-all-site-extensions.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName
-# 
+#
 # Example call of this script to remove all installed extensions in a resource group:
 # .\update-all-site-extensions.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -Remove
 #
 # Example call of this script using non-ambient credentials:
 # .\update-all-site-extensions.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -Username $username -Password $password -Remove
+#
+# Example call including deployment slots:
+# .\update-all-site-extensions.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroupName -IncludeSlots
 #
 
 if ($Username -eq "ambient") {
@@ -38,14 +44,14 @@ $userAgent = "powershell/1.0"
 $allSites=az webapp list -g $ResourceGroup | ConvertFrom-Json
 
 Foreach($webapp in @($allSites)) {
-	
+
 	$siteName=$webapp.name
 	$baseApiUrl = "https://$($webapp.enabledHostNames -like "*.scm.*")/api"
 	$siteExtensionsBase="${baseApiUrl}/siteextensions"
 	$siteExtensionManage="${baseApiUrl}/siteextensions/${extension}"
 
 	Write-Output "[${siteName}] Requesting installed extensions."
-	
+
 	$hasExtension=$false
 	$hasDesiredVersion=$false
 	$installedExtensions=Invoke-RestMethod -Uri $siteExtensionsBase -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
@@ -54,15 +60,15 @@ Foreach($webapp in @($allSites)) {
 	$hasExtension=$false
 
 	Foreach ($installedExtension in @($installedExtensions)){
-		
+
 		$extVersion=$installedExtension.version
 		$extId=$installedExtension.id
-		
+
 		if ($extId -eq $Extension) {
-			
+
 			$hasExtension=$true
 			$extensionUpdate="$PSScriptRoot\install-latest-extension.ps1 -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -SiteName $siteName -Username $Username -Password $Password -Extension $Extension"
-		
+
 			if ($Remove) {
 				$extensionUpdate="${extensionUpdate} -Remove"
 			}
@@ -79,13 +85,40 @@ Foreach($webapp in @($allSites)) {
 				Write-Output "[${siteName}] Latest version (${extVersion}) of ${Extension} already installed."
 				break;
 			}
-			
+
 			Write-Output "[${siteName}] Ready to modify ${Extension}."
 			iex $extensionUpdate
 		}
 	}
-	
+
 	if (-Not $hasExtension) {
 		Write-Output "[${siteName}] ${Extension} not found."
+	}
+
+	if ($IncludeSlots) {
+		$slots = az webapp deployment slot list -n $siteName -g $ResourceGroup | ConvertFrom-Json
+		Foreach ($slot in @($slots)) {
+			$slotName = $slot.name.Split('/')[-1]
+			$slotBaseApiUrl = "https://$($slot.enabledHostNames -like "*.scm.*")/api"
+			$slotExtensionsUrl = "${slotBaseApiUrl}/siteextensions"
+			$slotExtensionManage = "${slotBaseApiUrl}/siteextensions/${Extension}"
+
+			Write-Output "[${siteName}/${slotName}] Requesting installed extensions."
+			$installedExtensions = Invoke-RestMethod -Uri $slotExtensionsUrl -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
+
+			Foreach ($installedExtension in @($installedExtensions)) {
+				if ($installedExtension.id -eq $Extension) {
+					$extensionUpdate = "$PSScriptRoot\install-latest-extension.ps1 -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -SiteName $siteName -SlotName $slotName -Username $Username -Password $Password -Extension $Extension"
+					if ($Remove) { $extensionUpdate = "${extensionUpdate} -Remove" }
+					elseif ($requiresSpecificVersion) { $extensionUpdate = "${extensionUpdate} -ExtensionVersion ${ExtensionVersion}" }
+					elseif ($installedExtension.local_is_latest_version) {
+						Write-Output "[${siteName}/${slotName}] Latest version already installed."
+						break
+					}
+					Write-Output "[${siteName}/${slotName}] Ready to modify ${Extension}."
+					iex $extensionUpdate
+				}
+			}
+		}
 	}
 }

--- a/management-scripts/extension/update-all-site-extensions.ps1
+++ b/management-scripts/extension/update-all-site-extensions.ps1
@@ -101,13 +101,14 @@ Foreach($webapp in @($allSites)) {
 			$slotName = $slot.name.Split('/')[-1]
 			$slotBaseApiUrl = "https://$($slot.enabledHostNames -like "*.scm.*")/api"
 			$slotExtensionsUrl = "${slotBaseApiUrl}/siteextensions"
-			$slotExtensionManage = "${slotBaseApiUrl}/siteextensions/${Extension}"
 
 			Write-Output "[${siteName}/${slotName}] Requesting installed extensions."
 			$installedExtensions = Invoke-RestMethod -Uri $slotExtensionsUrl -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -UserAgent $userAgent -Method GET
 
+			$hasSlotExtension = $false
 			Foreach ($installedExtension in @($installedExtensions)) {
 				if ($installedExtension.id -eq $Extension) {
+					$hasSlotExtension = $true
 					$extensionUpdate = "$PSScriptRoot\install-latest-extension.ps1 -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -SiteName $siteName -SlotName $slotName -Username $Username -Password $Password -Extension $Extension"
 					if ($Remove) { $extensionUpdate = "${extensionUpdate} -Remove" }
 					elseif ($requiresSpecificVersion) { $extensionUpdate = "${extensionUpdate} -ExtensionVersion ${ExtensionVersion}" }
@@ -118,6 +119,9 @@ Foreach($webapp in @($allSites)) {
 					Write-Output "[${siteName}/${slotName}] Ready to modify ${Extension}."
 					iex $extensionUpdate
 				}
+			}
+			if (-Not $hasSlotExtension) {
+				Write-Output "[${siteName}/${slotName}] ${Extension} not found."
 			}
 		}
 	}

--- a/management-scripts/extension/update-all-site-extensions.ps1
+++ b/management-scripts/extension/update-all-site-extensions.ps1
@@ -46,7 +46,7 @@ $allSites=az webapp list -g $ResourceGroup | ConvertFrom-Json
 Foreach($webapp in @($allSites)) {
 
 	$siteName=$webapp.name
-	$baseApiUrl = "https://$($webapp.enabledHostNames -like "*.scm.*")/api"
+	$baseApiUrl = "https://$(($webapp.enabledHostNames -like "*.scm.*")[0])/api"
 	$siteExtensionsBase="${baseApiUrl}/siteextensions"
 	$siteExtensionManage="${baseApiUrl}/siteextensions/${extension}"
 
@@ -99,7 +99,7 @@ Foreach($webapp in @($allSites)) {
 		$slots = az webapp deployment slot list -n $siteName -g $ResourceGroup | ConvertFrom-Json
 		Foreach ($slot in @($slots)) {
 			$slotName = $slot.name.Split('/')[-1]
-			$slotBaseApiUrl = "https://$($slot.enabledHostNames -like "*.scm.*")/api"
+			$slotBaseApiUrl = "https://$(($slot.enabledHostNames -like "*.scm.*")[0])/api"
 			$slotExtensionsUrl = "${slotBaseApiUrl}/siteextensions"
 
 			Write-Output "[${siteName}/${slotName}] Requesting installed extensions."


### PR DESCRIPTION
## Summary

Addresses [#455](https://github.com/DataDog/datadog-aas-extension/issues/455) — intermittent `MoveDirectory` failures when installing the Datadog extension on Azure Function App deployment slots.

**Root cause:** The Functions runtime holds file locks on `C:\home\SiteExtensions\` after code deployment. If a site extension ARM deployment runs while those handles are open, Kudu's `MoveDirectory` step fails. This does not affect Web Apps.

**Fix:** Set `WEBSITE_PRIVATE_EXTENSIONS=0` as a sticky slot setting. This prevents the Functions runtime from loading private site extensions on that slot (releasing the file locks). Because the setting is sticky, it stays on the staging slot after swaps and never affects production.

## Changes

### `install-templates/` (renamed from `ARM/`)
- `install-web-app.{json,bicep}` — Web App install templates
- `install-web-app-slot.{json,bicep}` — Web App deployment slot templates
- `install-function-app-slot.{json,bicep}` — **New**: Function App slot templates with `WEBSITE_PRIVATE_EXTENSIONS=0` sticky setting + `slotConfigNames` resource, `dependsOn` ordering to ensure setting is applied before extension install
- All templates versioned (`metadata.version` in JSON, `// Version:` in Bicep) to allow comparison against docs inline snippets

### PowerShell scripts
- `install-latest-extension.ps1` **v2.0.0**: adds `-SlotName` parameter; when provided against a Function App, automatically applies `WEBSITE_PRIVATE_EXTENSIONS=0` as a sticky slot setting.
- `update-all-site-extensions.ps1` **v2.0.0**: adds `-IncludeSlots` flag to enumerate and update deployment slots across a resource group

### `README.md`
- Adds "In-repo resources" section pointing at `install-templates/` and `management-scripts/extension/`

## Companion PR

**Must be merged alongside:** [DataDog/documentation#36956](https://github.com/DataDog/documentation/pull/36956)

The docs PR updates the `ARM/` → `install-templates/` link and adds the new `azure_functions/dotnet_extension.md` page. The rename here will break the existing docs link until both land.

## Test plan

- [x] Verify JSON templates are valid (`python3 -m json.tool`)
- [x] Verify Bicep templates compile (`az bicep build`)
- [x] https://github.com/DataDog/serverless-init-self-monitoring/pull/415 demonstrates a function app deploy with fix in place 
- [x] Verify `install-latest-extension.ps1` with `-SlotName` on a Web App (no Function App branch taken)
- [x] Verify `install-latest-extension.ps1` with `-SlotName` on a Function App (sticky setting applied)
- [x] Verify `install-latest-extension.ps1` without `-SlotName` (behavior unchanged)
- [x] Verify `update-all-site-extensions.ps1` without `-IncludeSlots` (behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)