### PR TITLE
[CI] Trigger serverless-init self-monitoring instead of dead az-cli jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,3 +10,6 @@ variables:
     description: "Version of the extension to deploy. Ex. 1.0.0"
   AGENT_JOB_URL:
     description: "Optional. URL of a specific datadog-agent windows_zip_agent_binaries_x64-a7 GitLab job (e.g. 'https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1663094644'). When set with RUNTIME=node, fetch-agent-binaries-node pulls the agent zip from that job's artifacts (via gitlab_pat in vault) and the node build uses it instead of the default dsd6-staging zip."
+  SELF_MONITORING_REF:
+    description: "serverless-init-self-monitoring branch/tag the self-monitoring trigger jobs target. Defaults to main; override to test against a feature branch."
+    value: "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,6 @@ variables:
     description: "Version of the extension to deploy. Ex. 1.0.0"
   AGENT_JOB_URL:
     description: "Optional. URL of a specific datadog-agent windows_zip_agent_binaries_x64-a7 GitLab job (e.g. 'https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1663094644'). When set with RUNTIME=node, fetch-agent-binaries-node pulls the agent zip from that job's artifacts (via gitlab_pat in vault) and the node build uses it instead of the default dsd6-staging zip."
-  SELF_MONITORING_REF:
-    description: "serverless-init-self-monitoring branch/tag the self-monitoring trigger jobs target. Defaults to main; override to test against a feature branch."
+  SELF_MONITORING_BRANCH:
+    description: "serverless-init-self-monitoring branch the self-monitoring trigger jobs target. Defaults to main; override to test against a feature branch."
     value: "main"

--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -49,7 +49,7 @@ update-self-monitoring-java-dev:
     ENVIRONMENT: "rc"
   trigger:
     project: DataDog/serverless-init-self-monitoring
-    branch: $SELF_MONITORING_REF
+    branch: $SELF_MONITORING_BRANCH
     strategy: depend
 
 create-github-release-java:
@@ -111,5 +111,5 @@ update-self-monitoring-java-prod:
     ENVIRONMENT: "prod"
   trigger:
     project: DataDog/serverless-init-self-monitoring
-    branch: $SELF_MONITORING_REF
+    branch: $SELF_MONITORING_BRANCH
     strategy: depend

--- a/.gitlab/java.yml
+++ b/.gitlab/java.yml
@@ -38,28 +38,19 @@ push-nuget-package-java-dev:
     - dotnet nuget push package/DevelopmentVerification.DdJava.Apm.${DEVELOPMENT_VERSION}.nupkg --source Public_Feed_Java --api-key any_string
 
 update-self-monitoring-java-dev:
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/azure-cli:2.57.0
   rules:
     - if: $RUNTIME == "java"
   stage: test
   needs:
     - push-nuget-package-java-dev
-  script:
-    - apk update
-    - apk add aws-cli jq
-    - export AZ_SERVICE_PRINCIPAL=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.azure-service-principal --with-decryption --query "Parameter.Value" --out text)
-    - export AZ_APP_ID=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.appId')
-    - export AZ_PASSWORD=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.password')
-    - export AZ_TENANT=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.tenant')
-    - az login --service-principal -u $AZ_APP_ID -p $AZ_PASSWORD --tenant $AZ_TENANT
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows-java17-spring-self-monitoring-dev"
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows-java21-spring-self-monitoring-dev"
-    - sleep 30
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows-java17-spring-self-monitoring-dev/siteextensions/DevelopmentVerification.DdJava.Apm" --properties "{}" --debug
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows-java21-spring-self-monitoring-dev/siteextensions/DevelopmentVerification.DdJava.Apm" --properties "{}" --debug
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows-java17-spring-self-monitoring-dev"
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows-java21-spring-self-monitoring-dev"
+  variables:
+    AAS_EXTENSION_ONLY: "true"
+    AAS_EXTENSION_TYPE: "dev"
+    ENVIRONMENT: "rc"
+  trigger:
+    project: DataDog/serverless-init-self-monitoring
+    branch: $SELF_MONITORING_REF
+    strategy: depend
 
 create-github-release-java:
   tags: ["arch:amd64"]
@@ -108,23 +99,17 @@ push-nuget-package-java-prod:
     - dotnet nuget push package/Datadog.AzureAppServices.Java.Apm.${RELEASE_VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
 
 update-self-monitoring-java-prod:
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/azure-cli:2.57.0
   rules:
     - if: $RUNTIME == "java" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy
   needs:
     - push-nuget-package-java-prod
   when: manual # Need to wait about 15 minutes for nuget package to be indexed before updating self monitoring apps
-  script:
-    - apk update
-    - apk add aws-cli jq
-    - export AZ_SERVICE_PRINCIPAL=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.azure-service-principal --with-decryption --query "Parameter.Value" --out text)
-    - az login --service-principal -u $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.appId') -p $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.password') --tenant $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.tenant')
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows-java17-spring-self-monitoring"
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows-java21-spring-self-monitoring"
-    - sleep 30
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows-java17-spring-self-monitoring/siteextensions/Datadog.AzureAppServices.Java.Apm" --properties "{}" --debug
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows-java21-spring-self-monitoring/siteextensions/Datadog.AzureAppServices.Java.Apm" --properties "{}" --debug
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows-java17-spring-self-monitoring"
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows-java21-spring-self-monitoring"
+  variables:
+    AAS_EXTENSION_ONLY: "true"
+    AAS_EXTENSION_TYPE: "prod"
+    ENVIRONMENT: "prod"
+  trigger:
+    project: DataDog/serverless-init-self-monitoring
+    branch: $SELF_MONITORING_REF
+    strategy: depend

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -160,7 +160,7 @@ update-self-monitoring-node-dev:
     ENVIRONMENT: "rc"
   trigger:
     project: DataDog/serverless-init-self-monitoring
-    branch: $SELF_MONITORING_REF
+    branch: $SELF_MONITORING_BRANCH
     strategy: depend
 
 create-github-release-node:
@@ -222,5 +222,5 @@ update-self-monitoring-node-prod:
     ENVIRONMENT: "prod"
   trigger:
     project: DataDog/serverless-init-self-monitoring
-    branch: $SELF_MONITORING_REF
+    branch: $SELF_MONITORING_BRANCH
     strategy: depend

--- a/.gitlab/node.yml
+++ b/.gitlab/node.yml
@@ -149,28 +149,19 @@ push-nuget-package-node-dev:
     - dotnet nuget push package/DevelopmentVerification.DdNode.Apm.${DEVELOPMENT_VERSION}.nupkg --source Public_Feed_Node --api-key any_string
 
 update-self-monitoring-node-dev:
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/azure-cli:2.57.0
   rules:
     - if: $RUNTIME == "node"
   stage: test
   needs:
     - push-nuget-package-node-dev
-  script:
-    - apk update
-    - apk add aws-cli jq
-    - export AZ_SERVICE_PRINCIPAL=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.azure-service-principal --with-decryption --query "Parameter.Value" --out text)
-    - export AZ_APP_ID=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.appId')
-    - export AZ_PASSWORD=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.password')
-    - export AZ_TENANT=$(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.tenant')
-    - az login --service-principal -u $AZ_APP_ID -p $AZ_PASSWORD --tenant $AZ_TENANT
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring-dev"
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring-dev"
-    - sleep 30
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows32-node18-express-self-monitoring-dev/siteextensions/DevelopmentVerification.DdNode.Apm" --properties "{}" --debug
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows64-node18-express-self-monitoring-dev/siteextensions/DevelopmentVerification.DdNode.Apm" --properties "{}" --debug
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring-dev"
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring-dev"
+  variables:
+    AAS_EXTENSION_ONLY: "true"
+    AAS_EXTENSION_TYPE: "dev"
+    ENVIRONMENT: "rc"
+  trigger:
+    project: DataDog/serverless-init-self-monitoring
+    branch: $SELF_MONITORING_REF
+    strategy: depend
 
 create-github-release-node:
   tags: ["arch:amd64"]
@@ -219,23 +210,17 @@ push-nuget-package-node-prod:
     - dotnet nuget push package/Datadog.AzureAppServices.Node.Apm.${RELEASE_VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
 
 update-self-monitoring-node-prod:
-  tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/mirror/azure-cli:2.57.0
   rules:
     - if: $RUNTIME == "node" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   stage: deploy
   needs:
     - push-nuget-package-node-prod
   when: manual # Need to wait about 15 minutes for nuget package to be indexed before updating self monitoring apps
-  script:
-    - apk update
-    - apk add aws-cli jq
-    - export AZ_SERVICE_PRINCIPAL=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-aas-extension.azure-service-principal --with-decryption --query "Parameter.Value" --out text)
-    - az login --service-principal -u $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.appId') -p $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.password') --tenant $(echo "$AZ_SERVICE_PRINCIPAL" | jq -r '.tenant')
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring"
-    - az webapp stop --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring"
-    - sleep 30
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows32-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.Apm" --properties "{}" --debug
-    - az resource create --resource-group serverless-aas-win --resource-type "Microsoft.Web/sites/siteextensions" --name "serverless-windows64-node18-express-self-monitoring/siteextensions/Datadog.AzureAppServices.Node.Apm" --properties "{}" --debug
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows32-node18-express-self-monitoring"
-    - az webapp start --resource-group "serverless-aas-win" --name "serverless-windows64-node18-express-self-monitoring"
+  variables:
+    AAS_EXTENSION_ONLY: "true"
+    AAS_EXTENSION_TYPE: "prod"
+    ENVIRONMENT: "prod"
+  trigger:
+    project: DataDog/serverless-init-self-monitoring
+    branch: $SELF_MONITORING_REF
+    strategy: depend


### PR DESCRIPTION
## Summary

Retires the four dead `az`-CLI `update-self-monitoring-*` jobs in `node.yml` / `java.yml` and replaces them with cross-project `trigger:` jobs into `DataDog/serverless-init-self-monitoring`, which already owns the Azure self-monitoring fleet and authenticates to Azure via its own Vault path.

The old jobs `az login`'d with SSM `ci.datadog-aas-extension.azure-service-principal` (wrong tenant) and targeted RG `serverless-aas-win` (does not exist — `ResourceGroupNotFound`). We need to replace them with working tests. 

## Changes

- **`.gitlab-ci.yml`**: new `SELF_MONITORING_REF` variable (default `main`) driving the trigger's target branch, so runs can point at a serverless-init feature branch for testing.
- **`node.yml` / `java.yml`**: each `update-self-monitoring-*-dev/-prod` job keeps its name/stage/needs/rules/`when: manual`, but swaps the `az` body for a `trigger:` into serverless-init with `strategy: depend` (blocks the release on the downstream deploy + smoke result).

Variable mapping (reuses PR #486's `AAS_EXTENSION_ONLY`):

| tier | downstream vars |
|---|---|
| dev (`stage: test`)  | `AAS_EXTENSION_ONLY=true`, `AAS_EXTENSION_TYPE=dev`,  `ENVIRONMENT=rc` |
| prod (`stage: deploy`, manual) | `AAS_EXTENSION_ONLY=true`, `AAS_EXTENSION_TYPE=prod`, `ENVIRONMENT=prod` |

`AAS_EXTENSION_ONLY=true` deploys all extension apps (node + dotnet, plus java once its rows land) — accepted as harmless latest-from-feed reinstalls. Version can't be pinned; matches the old `-p '{}'` behavior.

## Co-merge prerequisites (not code in this repo)

serverless-init [#486](https://github.com/DataDog/serverless-init-self-monitoring/pull/486) (`AAS_EXTENSION_ONLY` + java coverage)  

## Test plan

- [x] `yq` parses all three files; each trigger job has `trigger.project = DataDog/serverless-init-self-monitoring` and no leftover `script`/`image`/`tags`.
- [x] No `serverless-aas-win` / `az login` references remain.
- [x] `create-github-release-*` still reference the (now trigger) `update-self-monitoring-*-dev` jobs.
- [x] Run a `web` pipeline with `RUNTIME=node` and `SELF_MONITORING_REF=<#486 branch>`; confirm the downstream serverless-init pipeline deploys only extension apps. See: https://gitlab.ddbuild.io/DataDog/serverless-init-self-monitoring/-/pipelines/126272495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
